### PR TITLE
Clang compile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,10 +370,10 @@ CFLAGS_KCOV	= -fsanitize-coverage=trace-pc
 
 # fall back to -march=armv8-a+crc+crypto in case the compiler isn't
 # compatible with -mcpu
-ARM_ARCH_OPT := -mcpu=cortex-a57+crc+crypto
+#ARM_ARCH_OPT := -mcpu=cortex-a57+crc+crypto
 GEN_OPT_FLAGS := $(call cc-option,$(ARM_ARCH_OPT),-march=armv8-a+crc+crypto) \
  -g0 -DNDEBUG \
- -fivopts $(MK_FLAGS)
+ -mcpu=kryo -mno-fix-cortex-a53-835769 $(MK_FLAGS)
 
 # Use USERINCLUDE when you must reference the UAPI directories only.
 USERINCLUDE    := \
@@ -414,14 +414,10 @@ KBUILD_LDFLAGS_MODULE := -T $(srctree)/scripts/module-common.lds
 
 # Snapdragon 820 doesn't need 835769/843419 erratum fixes
 # some toolchain enables those fixes automatically, so opt-out
-KBUILD_CFLAGS	+= $(call cc-option, -mno-fix-cortex-a53-835769)
-KBUILD_CFLAGS	+= $(call cc-option, -mno-fix-cortex-a53-843419)
-LDFLAGS_vmlinux	+= $(call ld-option, --no-fix-cortex-a53-835769)
-LDFLAGS_vmlinux	+= $(call ld-option, --no-fix-cortex-a53-843419)
-LDFLAGS_MODULE	+= $(call ld-option, --no-fix-cortex-a53-835769)
-LDFLAGS_MODULE	+= $(call ld-option, --no-fix-cortex-a53-843419)
-LDFLAGS		+= $(call ld-option, --no-fix-cortex-a53-835769)
-LDFLAGS		+= $(call ld-option, --no-fix-cortex-a53-843419)
+#KBUILD_CFLAGS	+= $(call cc-option, -mno-fix-cortex-a53-835769)
+#LDFLAGS_vmlinux	+= $(call ld-option, --no-fix-cortex-a53-843419)
+#LDFLAGS_MODULE	+= $(call ld-option, --no-fix-cortex-a53-835769)
+#LDFLAGS		+= $(call ld-option, --no-fix-cortex-a53-835769)
 
 # Read KERNELRELEASE from include/config/kernel.release (if it exists)
 KERNELRELEASE = $(shell cat include/config/kernel.release 2> /dev/null)

--- a/arch/arm64/Makefile
+++ b/arch/arm64/Makefile
@@ -31,20 +31,20 @@ ifeq ($(CONFIG_CPU_BIG_ENDIAN), y)
 KBUILD_CPPFLAGS	+= -mbig-endian
 AS		+= -EB
 LD		+= -EB
-ifeq ($(MK_LINKER),ld.gold)
-LDFLAGS		+= -maarch64_elf64_be_vec
-else
-LDFLAGS		+= -maarch64linuxb
-endif
+#ifeq ($(MK_LINKER),ld.gold)
+#LDFLAGS		+= -maarch64_elf64_be_vec
+#else
+#LDFLAGS		+= -maarch64linuxb
+#endif
 else
 KBUILD_CPPFLAGS	+= -mlittle-endian
 AS		+= -EL
 LD		+= -EL
-ifeq ($(MK_LINKER),ld.gold)
-LDFLAGS		+= -maarch64_elf64_le_vec
-else
-LDFLAGS		+= -maarch64linux
-endif
+#ifeq ($(MK_LINKER),ld.gold)
+#LDFLAGS		+= -maarch64_elf64_le_vec
+#else
+#LDFLAGS		+= -maarch64linux
+#endif
 endif
 
 CHECKFLAGS	+= -D__aarch64__

--- a/drivers/media/platform/msm/camera_v2/jpeg_10/msm_jpeg_sync.c
+++ b/drivers/media/platform/msm/camera_v2/jpeg_10/msm_jpeg_sync.c
@@ -117,7 +117,7 @@ struct msm_jpeg_hw_cmds32 {
 #endif
 
 
-inline void msm_jpeg_q_init(char const *name, struct msm_jpeg_q *q_p)
+static inline void msm_jpeg_q_init(char const *name, struct msm_jpeg_q *q_p)
 {
 	JPEG_DBG("%s:%d] %s\n", __func__, __LINE__, name);
 	q_p->name = name;


### PR DESCRIPTION
Sets -mcpu for clang and fixes a new warning that appeared with the new 8.0 version of llvm/clang