### PR TITLE
Mk2k 4.4: Add some fixes and bypasses.

### DIFF
--- a/drivers/input/touchscreen/lge/lgsic/touch_sw49407_abt.c
+++ b/drivers/input/touchscreen/lge/lgsic/touch_sw49407_abt.c
@@ -222,8 +222,8 @@ static int abt_ksocket_receive(unsigned char *buf, int len)
 	msg.msg_namelen  = sizeof(struct sockaddr_in);
 	msg.msg_control = NULL;
 	msg.msg_controllen = 0;
-	msg.msg_iov = &iov;
-	msg.msg_iovlen = 1;
+	//msg.msg_iov = &iov;
+	//msg.msg_iovlen = 1;
 	msg.msg_control = NULL;
 
 	oldfs = get_fs();
@@ -439,14 +439,14 @@ static uint32_t abt_ksocket_send_exit(void)
 	msg.msg_namelen  = sizeof(struct sockaddr_in);
 	msg.msg_control = NULL;
 	msg.msg_controllen = 0;
-	msg.msg_iov = &iov;
-	msg.msg_iovlen = 1;
+	//msg.msg_iov = &iov;
+	//msg.msg_iovlen = 1;
 	msg.msg_control = NULL;
 
 	oldfs = get_fs();
 
 	set_fs(KERNEL_DS);
-	ret = sock_sendmsg(sock, &msg, 1);
+	//ret = sock_sendmsg(sock, &msg, 1);
 	TOUCH_I(": exit send message return : %d\n", ret);
 	set_fs(oldfs);
 	sock_release(sock);
@@ -475,14 +475,14 @@ static int abt_ksocket_send(struct socket *sock,
 	msg.msg_namelen  = sizeof(struct sockaddr_in);
 	msg.msg_control = NULL;
 	msg.msg_controllen = 0;
-	msg.msg_iov = &iov;
-	msg.msg_iovlen = 1;
+	//msg.msg_iov = &iov;
+	//msg.msg_iovlen = 1;
 	msg.msg_control = NULL;
 
 	oldfs = get_fs();
 
 	set_fs(KERNEL_DS);
-	size = sock_sendmsg(sock, &msg, len);
+	//size = sock_sendmsg(sock, &msg, len);
 	set_fs(oldfs);
 
 	return size;

--- a/sound/soc/codecs/es9218.c
+++ b/sound/soc/codecs/es9218.c
@@ -2085,7 +2085,7 @@ static int es9218_set_bias_level(struct snd_soc_codec *codec,
 		case SND_SOC_BIAS_OFF:
 			break;
 	}
-	codec->dapm.bias_level = level;
+	codec->driver->set_bias_level(codec, level);
 
 	/* dev_dbg(codec->dev, "%s(): exit\n", __func__); */
 	return ret;


### PR DESCRIPTION
The es9218 driver had a small fix to fit better with the new soc sound driver structures, while the touchscreen driver had a bypass added to it.