### PR TITLE
Mk2k 4.4: Fix a few more warnings.

### DIFF
--- a/drivers/net/wireless/bcmdhd/src/wl/sys/wl_cfg80211.c
+++ b/drivers/net/wireless/bcmdhd/src/wl/sys/wl_cfg80211.c
@@ -1555,7 +1555,7 @@ wl_cfg80211_add_virtual_iface(struct wiphy *wiphy,
 #else
 	char *name,
 #endif /* WL_CFG80211_P2P_DEV_IF */
-	enum nl80211_iftype type, u32 *flags,
+	unsigned char uctype, enum nl80211_iftype type, u32 *flags,
 	struct vif_params *params)
 {
 	s32 err = -ENODEV;

--- a/net/netfilter/nf_conntrack_core.c
+++ b/net/netfilter/nf_conntrack_core.c
@@ -863,7 +863,7 @@ __nf_conntrack_alloc(struct net *net,
 	/* Don't set timer yet: wait for confirmation */
 	setup_timer(&ct->timeout, death_by_timeout, (unsigned long)ct);
 	write_pnet(&ct->ct_net, net);
-	memset(&ct->__nfct_init_offset[0], 0,
+	memset(&ct->__nfct_init_offset, 0,
 	       offsetof(struct nf_conn, proto) -
 	       offsetof(struct nf_conn, __nfct_init_offset[0]));
 


### PR DESCRIPTION
Now it should mostly complain about external kernel issues and the things we bypassed.