### PR TITLE
Mk2k 4.4: Redoing the glink fixes.

### DIFF
--- a/drivers/soc/qcom/glink.c
+++ b/drivers/soc/qcom/glink.c
@@ -5902,7 +5902,7 @@ void glink_xprt_ctx_iterator_init(struct xprt_ctx_iterator *xprt_i)
 
 	mutex_lock(&transport_list_lock_lha0);
 	xprt_i->xprt_list = &transport_list;
-	xprt_i->i_curr = list_entry(&transport_list,
+	xprt_i->i_curr = list_first_entry_or_null(&transport_list,
 			struct glink_core_xprt_ctx, list_node);
 }
 EXPORT_SYMBOL(glink_xprt_ctx_iterator_init);

--- a/drivers/soc/qcom/glink.c
+++ b/drivers/soc/qcom/glink.c
@@ -5902,7 +5902,7 @@ void glink_xprt_ctx_iterator_init(struct xprt_ctx_iterator *xprt_i)
 
 	mutex_lock(&transport_list_lock_lha0);
 	xprt_i->xprt_list = &transport_list;
-	xprt_i->i_curr = list_entry(&transport_list+3,
+	xprt_i->i_curr = list_entry(&transport_list,
 			struct glink_core_xprt_ctx, list_node);
 }
 EXPORT_SYMBOL(glink_xprt_ctx_iterator_init);

--- a/drivers/soc/qcom/glink_debugfs.c
+++ b/drivers/soc/qcom/glink_debugfs.c
@@ -452,7 +452,7 @@ static void glink_dfs_create_channel_list(struct seq_file *s)
 	seq_puts(s,
 		"-------------------------------------------------------------------------------\n");
 	glink_xprt_ctx_iterator_init(&xprt_iter);
-	xprt_ctx = glink_xprt_ctx_iterator_next(&xprt_iter);
+	xprt_ctx = xprt_iter.i_curr;
 
 	while (xprt_ctx != NULL) {
 		glink_ch_ctx_iterator_init(&ch_iter, xprt_ctx);
@@ -511,7 +511,7 @@ static void glink_dfs_create_xprt_list(struct seq_file *s)
 	seq_puts(s,
 		"-------------------------------------------------------------------------------\n");
 	glink_xprt_ctx_iterator_init(&xprt_iter);
-	xprt_ctx = glink_xprt_ctx_iterator_next(&xprt_iter);
+	xprt_ctx = xprt_iter.i_curr;
 
 	while (xprt_ctx != NULL) {
 		count++;


### PR DESCRIPTION
Kerneltoast's fixes are better, even if both achieve the same end goal, so we're going with his changes.