### PR TITLE
Mk2k 4.4: A few fixes in dwc3, smb1351, battery_manager and also a few more QoL debug improvements.

### DIFF
--- a/drivers/power/supply/qcom/Makefile
+++ b/drivers/power/supply/qcom/Makefile
@@ -9,3 +9,4 @@ obj-$(CONFIG_BATTERY_BCL) += battery_current_limit.o
 obj-$(CONFIG_QPNP_SMB2)		+= step-chg-jeita.o battery.o qpnp-smb2.o smb-lib.o pmic-voter.o storm-watch.o
 obj-$(CONFIG_SMB138X_CHARGER)	+= battery.o smb138x-charger.o smb-lib.o pmic-voter.o storm-watch.o
 obj-$(CONFIG_QPNP_QNOVO)	+= battery.o qpnp-qnovo.o
+obj-$(CONFIG_LGE_PM) += lge_battery_manager.o

--- a/drivers/power/supply/qcom/lge_battery_manager.c
+++ b/drivers/power/supply/qcom/lge_battery_manager.c
@@ -191,7 +191,7 @@ static int batt_mngr_get_fg_prop(struct power_supply *psy,
 		return -ENODEV;
 	}
 
-	rc = psy->get_property(psy, prop, &val);
+	rc = psy->desc->get_property(psy, prop, &val);
 	*value = val.intval;
 	if (unlikely(rc))
 		pr_bm(PR_ERR, "%s, rc: %d, intval: %d\n",
@@ -291,7 +291,7 @@ static int batt_mngr_set_fg_prop(struct power_supply *psy,
 	}
 
 	val.intval = value;
-	rc = psy->set_property(psy, prop, &val);
+	rc = psy->desc->set_property(psy, prop, &val);
 	if (unlikely(rc))
 		pr_bm(PR_ERR, "%s, rc: %d, intval: %d\n",
 			__func__, rc, value);
@@ -868,11 +868,11 @@ static int batt_mngr_probe(struct platform_device *pdev)
 		goto error;
 	}
 
-	bm->batt_mngr_psy.name = BM_PSY_NAME;
-	bm->batt_mngr_psy.get_property = batt_mngr_get_property;
-	bm->batt_mngr_psy.set_property = batt_mngr_set_property;
+	bm->batt_mngr_psy.desc->name = BM_PSY_NAME;
+	bm->batt_mngr_psy.desc->get_property = batt_mngr_get_property;
+	bm->batt_mngr_psy.desc->set_property = batt_mngr_set_property;
 
-	ret = power_supply_register(bm->dev, &bm->batt_mngr_psy);
+	ret = power_supply_register(bm->dev, &bm->batt_mngr_psy.desc, NULL);
 	if (ret < 0) {
 		pr_bm(PR_ERR, "%s power_supply_register charger controller failed ret=%d\n",
 			__func__, ret);

--- a/drivers/power/supply/qcom/smb1351-charger.c
+++ b/drivers/power/supply/qcom/smb1351-charger.c
@@ -1527,7 +1527,7 @@ static int smb1351_parallel_set_chg_suspend(struct smb1351_charger *chip,
 			return rc;
 		}
 
-/* #ifdef CONFIG_LGE_PM_PARALLEL_CHARGING
+#ifdef CONFIG_LGE_PM_PARALLEL_CHARGING
 		// adapter allowance to 5~9V
 		rc = smb1351_masked_write(chip, FLEXCHARGER_REG,
 					CHG_CONFIG_MASK, 0);
@@ -1550,7 +1550,7 @@ static int smb1351_parallel_set_chg_suspend(struct smb1351_charger *chip,
 			pr_err("Couldn't set soft hot limit rc = %d\n", rc);
 			return rc;
 		}
-#endif */
+#endif
 		chip->parallel_charger_suspended = false;
 	} else {
 		rc = smb1351_usb_suspend(chip, CURRENT, true);
@@ -1639,10 +1639,10 @@ static int smb1351_parallel_set_property(struct power_supply *psy,
 		 */
 		if (!chip->parallel_charger_suspended)
 			rc = smb1351_usb_suspend(chip, USER, !val->intval);
-/* #ifdef CONFIG_LGE_PM_PARALLEL_CHARGING
+#ifdef CONFIG_LGE_PM_PARALLEL_CHARGING
 		else
 			chip->usb_suspended_status &= ~USER;
-#endif */
+#endif
 		break;
 	case POWER_SUPPLY_PROP_INPUT_SUSPEND:
 		rc = smb1351_parallel_set_chg_suspend(chip, val->intval);

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -54,9 +54,9 @@
 #include "dbm.h"
 #include "debug.h"
 #include "xhci.h"
-/* #ifdef CONFIG_LGE_PM
+#ifdef CONFIG_LGE_PM
 #include <soc/qcom/lge/board_lge.h>
-#endif */
+#endif
 
 #define SDP_CONNETION_CHECK_TIME 10000 /* in ms */
 
@@ -186,6 +186,15 @@ enum plug_orientation {
 #define PM_QOS_SAMPLE_SEC	2
 #define PM_QOS_THRESHOLD	400
 
+enum dwc3_chg_type {
+	DWC3_INVALID_CHARGER = 0,
+	DWC3_SDP_CHARGER,
+	DWC3_DCP_CHARGER,
+	DWC3_CDP_CHARGER,
+	DWC3_PROPRIETARY_CHARGER,
+	DWC3_FLOATED_CHARGER,
+};
+
 struct dwc3_msm {
 	struct device *dev;
 	void __iomem *base;
@@ -226,6 +235,7 @@ struct dwc3_msm {
 	struct workqueue_struct *sm_usb_wq;
 	struct delayed_work	sm_work;
 	unsigned long		inputs;
+	enum dwc3_chg_type	chg_type;
 	unsigned		max_power;
 	bool			charging_disabled;
 	enum dwc3_drd_state	drd_state;
@@ -249,9 +259,9 @@ struct dwc3_msm {
 #define MDWC3_ASYNC_IRQ_WAKE_CAPABILITY	BIT(1)
 #define MDWC3_POWER_COLLAPSE		BIT(2)
 
-/* #ifdef CONFIG_LGE_PM
+#ifdef CONFIG_LGE_PM
 	bool xo_vote_for_charger;
-#endif */
+#endif
 	unsigned int		irq_to_affin;
 	struct notifier_block	dwc3_cpu_notifier;
 	struct notifier_block	usbdev_nb;
@@ -2181,7 +2191,7 @@ static int dwc3_msm_suspend(struct dwc3_msm *mdwc, bool hibernation)
 	 */
 	clk_disable_unprepare(mdwc->iface_clk);
 	/* USB PHY no more requires TCXO */
-/* #ifdef CONFIG_LGE_PM
+#ifdef CONFIG_LGE_PM
 	if (lge_get_boot_mode() != LGE_BOOT_MODE_CHARGERLOGO) {
 		if (!mdwc->xo_vote_for_charger) {
 			clk_disable_unprepare(mdwc->xo_clk);
@@ -2190,9 +2200,9 @@ static int dwc3_msm_suspend(struct dwc3_msm *mdwc, bool hibernation)
 		}
 	} else
 		clk_disable_unprepare(mdwc->xo_clk);
-#else */
+#else
 	clk_disable_unprepare(mdwc->xo_clk);
-//#endif
+#endif
 
 	/* Perform controller power collapse */
 	if ((!mdwc->in_host_mode && (!mdwc->in_device_mode || mdwc->in_restart))
@@ -2277,7 +2287,7 @@ static int dwc3_msm_resume(struct dwc3_msm *mdwc)
 	}
 
 	/* Vote for TCXO while waking up USB HSPHY */
-/* #ifdef CONFIG_LGE_PM
+#ifdef CONFIG_LGE_PM
 	if (lge_get_boot_mode() != LGE_BOOT_MODE_CHARGERLOGO) {
 		if (!mdwc->xo_vote_for_charger) {
 			ret = clk_prepare_enable(mdwc->xo_clk);
@@ -2296,12 +2306,12 @@ static int dwc3_msm_resume(struct dwc3_msm *mdwc)
 			dev_err(mdwc->dev, "%s failed to vote TCXO buffer%d\n",
 					__func__, ret);
 	}
-#else */
+#else
 	ret = clk_prepare_enable(mdwc->xo_clk);
 	if (ret)
 		dev_err(mdwc->dev, "%s failed to vote TCXO buffer%d\n",
 						__func__, ret);
-//#endif
+#endif
 
 	/* Restore controller power collapse */
 	if (mdwc->lpm_flags & MDWC3_POWER_COLLAPSE) {
@@ -3485,9 +3495,9 @@ static int dwc3_msm_remove(struct platform_device *pdev)
 	clk_disable_unprepare(mdwc->xo_clk);
 	clk_put(mdwc->xo_clk);
 
-/* #ifdef CONFIG_LGE_PM
+#ifdef CONFIG_LGE_PM
 	mdwc->xo_vote_for_charger = false;
-#endif */
+#endif
 
 	dwc3_msm_config_gdsc(mdwc, 0);
 
@@ -3937,7 +3947,7 @@ set_prop:
 
 	mdwc->max_power = mA;
 
-/* #ifdef CONFIG_LGE_PM
+#ifdef CONFIG_LGE_PM
 	if (lge_get_boot_mode() != LGE_BOOT_MODE_CHARGERLOGO) {
 		if (mdwc->chg_type == DWC3_DCP_CHARGER && mA != 0) {
 			if (!mdwc->xo_vote_for_charger) {
@@ -3968,7 +3978,7 @@ set_prop:
 			}
 		}
 	}
-#endif */
+#endif
 	return 0;
 }
 

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -3374,13 +3374,14 @@ static int dwc3_msm_probe(struct platform_device *pdev)
 		mdwc->pm_qos_latency = 0;
 	}
 
-	mdwc->usb_psy = power_supply_get_by_name("usb");
+	mdwc->usb_psy = power_supply_get_by_name("usb_pd");
 	if (!mdwc->usb_psy) {
 		dev_warn(mdwc->dev, "Could not get usb power_supply\n");
 		pval.intval = -EINVAL;
 	} else {
 		power_supply_get_property(mdwc->usb_psy,
 			POWER_SUPPLY_PROP_PRESENT, &pval);
+		dev_info(mdwc->dev, "USB PSY connected!\n");
 	}
 
 	mutex_init(&mdwc->suspend_resume_mutex);
@@ -3517,7 +3518,7 @@ static int dwc3_msm_host_notifier(struct notifier_block *nb,
 		return NOTIFY_DONE;
 
 	if (!mdwc->usb_psy) {
-		mdwc->usb_psy = power_supply_get_by_name("usb");
+		mdwc->usb_psy = power_supply_get_by_name("usb_pd");
 		if (!mdwc->usb_psy)
 			return NOTIFY_DONE;
 	}
@@ -3902,11 +3903,12 @@ int get_psy_type(struct dwc3_msm *mdwc)
 		return -EINVAL;
 
 	if (!mdwc->usb_psy) {
-		mdwc->usb_psy = power_supply_get_by_name("usb");
+		mdwc->usb_psy = power_supply_get_by_name("usb_pd");
 		if (!mdwc->usb_psy) {
 			dev_err(mdwc->dev, "Could not get usb psy\n");
 			return -ENODEV;
 		}
+		dev_info(mdwc->dev, "USB PSY found! Getting type...\n");
 	}
 
 	power_supply_get_property(mdwc->usb_psy, POWER_SUPPLY_PROP_REAL_TYPE,

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -2853,9 +2853,9 @@ static void dwc3_gadget_reset_interrupt(struct dwc3 *dwc)
 	dwc3_notify_event(dwc, DWC3_CONTROLLER_NOTIFY_OTG_EVENT, 0);
 
 	dwc3_usb3_phy_suspend(dwc, false);
-//#ifndef CONFIG_LGE_PM
+#ifndef CONFIG_LGE_PM
 	usb_gadget_vbus_draw(&dwc->gadget, 100);
-//#endif
+#endif
 
 	dwc3_reset_gadget(dwc);
 	dbg_event(0xFF, "BUS RST", 0);

--- a/drivers/usb/misc/anx7688/anx7688_core.c
+++ b/drivers/usb/misc/anx7688/anx7688_core.c
@@ -2183,7 +2183,7 @@ static int anx7688_probe(struct i2c_client *client,
 {
 	struct anx7688_chip *chip;
 	struct device *cdev = &client->dev;
-	struct power_supply *usb_psy, *test_psy;
+	struct power_supply *usb_psy;
 	struct power_supply *batt_psy;
 	struct dual_role_phy_desc *desc;
 	struct dual_role_phy_instance *dual_role;
@@ -2381,8 +2381,8 @@ static int anx7688_probe(struct i2c_client *client,
 		
 		//ret = 
 		chip->usbpd_psy = *power_supply_register(cdev, chip->usbpd_psy.desc, NULL); // That assignment is weird, but gcc doesn't complain.
-		test_psy = &chip->usbpd_psy;
-		if (!test_psy) { // Not sure if the check works as intended now... better than not having it though.
+		dev_info(cdev, "USB PSY name: %s\n", chip->usbpd_psy.desc->name);
+		if (!chip->usbpd_psy) { // Not sure if the check works as intended now... better than not having it though.
 			dev_err(cdev, "unalbe to register psy rc = %d\n", ret);
 			goto err7;
 		}

--- a/drivers/usb/misc/anx7688/anx7688_core.c
+++ b/drivers/usb/misc/anx7688/anx7688_core.c
@@ -2382,7 +2382,7 @@ static int anx7688_probe(struct i2c_client *client,
 		//ret = 
 		chip->usbpd_psy = *power_supply_register(cdev, chip->usbpd_psy.desc, NULL); // That assignment is weird, but gcc doesn't complain.
 		dev_info(cdev, "USB PSY name: %s\n", chip->usbpd_psy.desc->name);
-		if (!chip->usbpd_psy) { // Not sure if the check works as intended now... better than not having it though.
+		if (strcmp(chip->usbpd_psy.desc->name, "usb_pd") != 0) { // Not sure if the check works as intended now... checks if the psy has the correct name.
 			dev_err(cdev, "unalbe to register psy rc = %d\n", ret);
 			goto err7;
 		}


### PR DESCRIPTION
Adds a bit more info in the kernel logs, and also makes dwc3 look for the correct name for the usb based on 3.18, lge_battery_manager has been updated to the new power_supply structure as well.