### PR TITLE
Another small fix to lge_battery_manager.c.

### DIFF
--- a/drivers/power/supply/qcom/lge_battery_manager.c
+++ b/drivers/power/supply/qcom/lge_battery_manager.c
@@ -872,8 +872,8 @@ static int batt_mngr_probe(struct platform_device *pdev)
 	bm->batt_mngr_psy.desc->get_property = batt_mngr_get_property;
 	bm->batt_mngr_psy.desc->set_property = batt_mngr_set_property;
 
-	ret = power_supply_register(bm->dev, &bm->batt_mngr_psy.desc, NULL);
-	if (ret < 0) {
+	bm->batt_mngr_psy = *power_supply_register(bm->dev, bm->batt_mngr_psy.desc, NULL);
+	if (strcmp(bm->batt_mngr_psy.desc->name, BM_PSY_NAME) != 0) {
 		pr_bm(PR_ERR, "%s power_supply_register charger controller failed ret=%d\n",
 			__func__, ret);
 		goto error;


### PR DESCRIPTION
I forgot that the supply_register function returns a pointer instead of an integer now, so a few changes were needed to make it work correctly
as the anx7688 driver in regards to the supply register and check procedures.