### PR TITLE
Mk2k 4.4: Deferring the dwc3 probe, adding some psy code, etc.

### DIFF
--- a/drivers/power/power_supply_core.c
+++ b/drivers/power/power_supply_core.c
@@ -119,9 +119,7 @@ void power_supply_changed(struct power_supply *psy)
 	psy->changed = true;
 	pm_stay_awake(&psy->dev);
 	spin_unlock_irqrestore(&psy->changed_lock, flags);
-	queue_delayed_work(system_power_efficient_wq,
-			   &psy->deferred_register_work,
-			   POWER_SUPPLY_DEFERRED_REGISTER_TIME);
+	schedule_work(&psy->changed_work);
 }
 EXPORT_SYMBOL_GPL(power_supply_changed);
 

--- a/drivers/power/power_supply_sysfs.c
+++ b/drivers/power/power_supply_sysfs.c
@@ -47,7 +47,7 @@ static ssize_t power_supply_show_property(struct device *dev,
 		"Unknown", "Battery", "UPS", "Mains", "USB", "USB_DCP",
 		"USB_CDP", "USB_ACA", "USB_HVDCP", "USB_HVDCP_3", "USB_PD",
 		"Wireless", "USB_FLOAT", "BMS", "Parallel", "Main", "Wipower",
-		"TYPEC", "TYPEC_UFP", "TYPEC_DFP"
+		"TYPEC", "TYPEC_UFP", "TYPEC_DFP", "USB_C"
 	};
 	static char *status_text[] = {
 		"Unknown", "Charging", "Discharging", "Not charging", "Full"
@@ -88,7 +88,11 @@ static ssize_t power_supply_show_property(struct device *dev,
 	const ptrdiff_t off = attr - power_supply_attrs;
 	union power_supply_propval value;
 
+#ifdef CONFIG_LGE_PM
+	if (off == POWER_SUPPLY_PROP_TYPE && !!strcmp(psy->desc->name, "usb")) {
+#else
 	if (off == POWER_SUPPLY_PROP_TYPE) {
+#endif
 		value.intval = psy->desc->type;
 	} else {
 		ret = power_supply_get_property(psy, off, &value);
@@ -114,8 +118,12 @@ static ssize_t power_supply_show_property(struct device *dev,
 		return sprintf(buf, "%s\n", technology_text[value.intval]);
 	else if (off == POWER_SUPPLY_PROP_CAPACITY_LEVEL)
 		return sprintf(buf, "%s\n", capacity_level_text[value.intval]);
-	else if (off == POWER_SUPPLY_PROP_TYPE ||
-			off == POWER_SUPPLY_PROP_REAL_TYPE)
+#ifdef CONFIG_LGE_PM
+	else if (off == POWER_SUPPLY_PROP_TYPE
+			|| off == POWER_SUPPLY_PROP_REAL_TYPE)
+#else
+	else if (off == POWER_SUPPLY_PROP_TYPE)
+#endif
 		return sprintf(buf, "%s\n", type_text[value.intval]);
 	else if (off == POWER_SUPPLY_PROP_SCOPE)
 		return sprintf(buf, "%s\n", scope_text[value.intval]);

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -3374,10 +3374,11 @@ static int dwc3_msm_probe(struct platform_device *pdev)
 		mdwc->pm_qos_latency = 0;
 	}
 
-	mdwc->usb_psy = power_supply_get_by_name("usb_pd");
+	mdwc->usb_psy = power_supply_get_by_name("usb");
 	if (!mdwc->usb_psy) {
-		dev_warn(mdwc->dev, "Could not get usb power_supply\n");
-		pval.intval = -EINVAL;
+		dev_warn(mdwc->dev, "Could not get usb power_supply, deferring probe\n");
+		//pval.intval = -EINVAL;
+		return -EPROBE_DEFER;
 	} else {
 		power_supply_get_property(mdwc->usb_psy,
 			POWER_SUPPLY_PROP_PRESENT, &pval);
@@ -3518,7 +3519,7 @@ static int dwc3_msm_host_notifier(struct notifier_block *nb,
 		return NOTIFY_DONE;
 
 	if (!mdwc->usb_psy) {
-		mdwc->usb_psy = power_supply_get_by_name("usb_pd");
+		mdwc->usb_psy = power_supply_get_by_name("usb");
 		if (!mdwc->usb_psy)
 			return NOTIFY_DONE;
 	}
@@ -3903,10 +3904,10 @@ int get_psy_type(struct dwc3_msm *mdwc)
 		return -EINVAL;
 
 	if (!mdwc->usb_psy) {
-		mdwc->usb_psy = power_supply_get_by_name("usb_pd");
+		mdwc->usb_psy = power_supply_get_by_name("usb");
 		if (!mdwc->usb_psy) {
-			dev_err(mdwc->dev, "Could not get usb psy\n");
-			return -ENODEV;
+			dev_err(mdwc->dev, "Could not get usb psy, deferring probe.\n");
+			return -EPROBE_DEFER;
 		}
 		dev_info(mdwc->dev, "USB PSY found! Getting type...\n");
 	}


### PR DESCRIPTION
The previous kernel warning from power_supply_changed in anx7688 has returned and thus we need another way of fixing it, but that's for later.