### PR TITLE
Mk2k 4.4: Even more usb fixes.

### DIFF
--- a/arch/arm64/boot/dts/lge/msm8996-lineage.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-lineage.dtsi
@@ -61,6 +61,5 @@
 };
 
 &pmi8994_charger {
-	qcom,external-typec;
 	qcom,typec-psy-name = "usb_pd";
 };

--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -1222,8 +1222,6 @@ static void get_property_from_typec(struct smbchg_chip *chip,
 				union power_supply_propval *prop)
 {
 	int rc;
-	dev_info(chip->dev, "Getting typec psy name ->");
-	dev_info(chip->dev, "TYPEC_PSY_name: %s\n", chip->typec_psy->desc->name);
 
 	if (!chip->typec_psy) {
 		chip->typec_psy = power_supply_get_by_name("usb_pd");
@@ -1234,10 +1232,13 @@ static void get_property_from_typec(struct smbchg_chip *chip,
 		}
 	}
 
-	dev_info(chip->dev, "NEW_TYPEC_PSY_name: %s\n", chip->typec_psy->desc->name);
+	dev_info(chip->dev, "Getting type_c property\n");
 
 	rc = power_supply_get_property(chip->typec_psy,
 			property, prop);
+
+	dev_info(chip->dev, "Type_c property retrieved successfully.\n");
+
 	if (rc)
 		pr_smb(PR_TYPEC,
 			"typec psy doesn't support reading prop %d rc = %d\n",

--- a/drivers/usb/misc/anx7418/anx7418_charger.c
+++ b/drivers/usb/misc/anx7418/anx7418_charger.c
@@ -70,14 +70,14 @@ static int chg_get_property(struct power_supply *psy,
 		val->intval = chg->psy.desc->type;
 		break;
 
-	case POWER_SUPPLY_PROP_TYPEC_MODE:
+	/*case POWER_SUPPLY_PROP_TYPEC_MODE:
 		rc = anx7418_read_reg(anx->client, CC_STATUS);
 		dev_dbg(cdev, "%s: CC_STATUS(%02X)\n", __func__, rc);
 
 		val->intval = (rc == 0x11) ?
 			POWER_SUPPLY_TYPEC_SINK_DEBUG_ACCESSORY :
 			POWER_SUPPLY_TYPE_UNKNOWN;
-		break;
+		break;*/
 
 	default:
 		return -EINVAL;
@@ -309,18 +309,18 @@ int anx7418_charger_init(struct anx7418 *anx)
 	usb_psy->supplied_to = chg_supplicants;
 	usb_psy->num_supplicants = ARRAY_SIZE(chg_supplicants);
 	chg->psy = *usb_psy;
+	kfree(usb_psy);
 
 	chg->anx = anx;
 	INIT_DELAYED_WORK(&chg->chg_work, chg_work);
 
 	//rc = 
-	chg->psy = *power_supply_register(cdev, chg->psy.desc, NULL);
-	test_psy = &chg->psy;
+	test_psy = power_supply_register(cdev, chg->psy.desc, NULL);
 	if (!test_psy) {
 		dev_err(cdev, "Unalbe to register ctype_psy");
 		return -EPROBE_DEFER;
 	}
-
+	
 	dev_info(cdev, "Charger init done, configured and registered.");
 	return 0;
 }

--- a/drivers/usb/misc/anx7688/anx7688_core.c
+++ b/drivers/usb/misc/anx7688/anx7688_core.c
@@ -663,26 +663,16 @@ static int usbpd_get_property(struct power_supply *psy,
 		val->intval = chip->curr_max;
 		break;
 #endif
-
-#ifdef CONFIG_LGE_USB_ANX7688_OVP
-	case POWER_SUPPLY_PROP_TYPE:
-		dev_dbg(&chip->client->dev, "%s: Rp %dK\n", __func__,
-			chip->rp.intval);
-		val->intval = chip->rp.intval;
-		break;
 #ifdef CONFIG_LGE_PM_LGE_POWER_CLASS_SIMPLE
 	case POWER_SUPPLY_PROP_DP_ALT_MODE:
 		val->intval = chip->dp_alt_mode;
 #endif
-#else
 	case POWER_SUPPLY_PROP_TYPE:
 		val->intval = chip->usbpd_psy.desc->type;
 		break;
-#endif
 	default:
 		return -EINVAL;
 	}
-
         return 0;
 }
 
@@ -715,6 +705,7 @@ static int usbpd_set_property(struct power_supply *psy,
 			/* wait for vbus boost diacharging */
 			mdelay(200);
 		}
+		dev_info(cdev, "Setup USBPD PSY OTG");
 		break;
 	case POWER_SUPPLY_PROP_PRESENT:
 		if (val->intval) {
@@ -740,8 +731,6 @@ static int usbpd_set_property(struct power_supply *psy,
 						DUAL_ROLE_PROP_DR_NONE) {
 						anx7688_set_data_role(chip,
 							DUAL_ROLE_PROP_DR_DEVICE);
-				}
-#else
 				}
 #endif
 			}
@@ -772,8 +761,10 @@ static int usbpd_set_property(struct power_supply *psy,
 			/* Do nothing */
 			;
 #endif
+		}
 
 		if (chip->is_present == val->intval)
+			dev_info(cdev, "Setup USBPD PSY Present");
 			break;
 
 		chip->is_present = val->intval;
@@ -787,45 +778,38 @@ static int usbpd_set_property(struct power_supply *psy,
 			chip->volt_max = 0;
 			chip->charger_type = USBC_UNKNWON_CHARGER;
 		}
-
+		dev_info(cdev, "Setup USBPD PSY Present");
 		break;
 
-		case POWER_SUPPLY_PROP_VOLTAGE_MAX:
-			chip->volt_max = val->intval;
-			break;
+	case POWER_SUPPLY_PROP_VOLTAGE_MAX:
+		chip->volt_max = val->intval;
+		break;
 
-		case POWER_SUPPLY_PROP_CURRENT_MAX:
-			chip->curr_max = val->intval;
-			break;
+	case POWER_SUPPLY_PROP_CURRENT_MAX:
+		chip->curr_max = val->intval;
+		break;
 
-#ifdef CONFIG_LGE_USB_ANX7688_OVP
-		case POWER_SUPPLY_PROP_TYPE:
-			chip->rp.intval = val->intval;
-			dev_dbg(cdev, "%s: Rp %dK\n", __func__, chip->rp.intval);
-			chip->batt_psy->desc->set_property(chip->batt_psy,
-					POWER_SUPPLY_PROP_TYPE, &chip->rp);
+	case POWER_SUPPLY_PROP_TYPE:
+		dev_info(cdev, "Setting up USBPD PSY Type.");
+		switch (val->intval) {
+		case POWER_SUPPLY_TYPE_TYPEC:
+		case POWER_SUPPLY_TYPE_USB_PD:
+		case POWER_SUPPLY_TYPE_USB_HVDCP:
+		case POWER_SUPPLY_TYPE_USB_HVDCP_3:
+			psy->desc->type = val->intval;
+			dev_info(cdev, "USBPD PSY Type Setup done.");
 			break;
-
-#else 
-		case POWER_SUPPLY_PROP_TYPE:
-			switch (val->intval) {
-			case POWER_SUPPLY_TYPE_TYPEC:
-			case POWER_SUPPLY_TYPE_USB_PD:
-			case POWER_SUPPLY_TYPE_USB_HVDCP:
-			case POWER_SUPPLY_TYPE_USB_HVDCP_3:
-				psy->desc.type = val->intval;
-				break;
-			default:
-				psy->desc.type = POWER_SUPPLY_TYPE_UNKNOWN;
-				break;
-			}
-			break;
-
-#endif
 		default:
-			return -EINVAL;
+			
+			psy->desc->type = POWER_SUPPLY_TYPE_UNKNOWN;
+			dev_info(cdev, "Setup USBPD PSY Type as unknown");
+			break;
 		}
+		break;		
+	default:
+		return -EINVAL;
 	}
+
 	return 0;
 }
 
@@ -2337,7 +2321,7 @@ static int anx7688_probe(struct i2c_client *client,
 {
 	struct anx7688_chip *chip;
 	struct device *cdev = &client->dev;
-	struct power_supply *usb_psy, *test_psy, *usbpd_psy;
+	struct power_supply *usb_psy, *test_psy = NULL, *usbpd_psy = NULL;
 	struct power_supply *batt_psy;
 	struct dual_role_phy_desc *desc;
 	struct dual_role_phy_instance *dual_role;
@@ -2532,12 +2516,13 @@ static int anx7688_probe(struct i2c_client *client,
 		usbpd_psy->supplied_to = usbpd_supplicants;
 		usbpd_psy->num_supplicants = ARRAY_SIZE(usbpd_supplicants);
 		chip->usbpd_psy = *usbpd_psy;
-		
 		kfree(usbpd_psy);
+		
 		//ret = 
+		dev_info(cdev, "Created USB PSY name: %s\n", chip->usbpd_psy.desc->name);
 		test_psy = power_supply_register(cdev, chip->usbpd_psy.desc, NULL); // That assignment is weird, but gcc doesn't complain.
-		dev_info(cdev, "USB PSY name: %s\n", test_psy->desc->name);
-		if (test_psy) { // Not sure if the check works as intended now... checks if the psy has the correct name.
+		dev_info(cdev, "Test USB PSY name: %s\n", test_psy->desc->name);
+		if (!test_psy) { // Not sure if the check works as intended now... checks if the psy has the correct name.
 			dev_err(cdev, "unalbe to register psy rc = %d\n", ret);
 			goto err7;
 		}


### PR DESCRIPTION
The V20 goes even further now with working battery detection and usb insertion event handling, while the G5 should receive some extra debugging code soon, as its anx7418 driver is the priority now.