### PR TITLE
Mk2k 4.4: Revert some previous psy changes, and readd the improved queuing but only for 7688.

### DIFF
--- a/drivers/power/power_supply_core.c
+++ b/drivers/power/power_supply_core.c
@@ -119,7 +119,13 @@ void power_supply_changed(struct power_supply *psy)
 	psy->changed = true;
 	pm_stay_awake(&psy->dev);
 	spin_unlock_irqrestore(&psy->changed_lock, flags);
+#ifdef CONFIG_LGE_USB_ANX7688
+	queue_delayed_work(system_power_efficient_wq,
+			   &psy->deferred_register_work,
+			   msecs_to_jiffies(25));
+#else
 	schedule_work(&psy->changed_work);
+#endif
 }
 EXPORT_SYMBOL_GPL(power_supply_changed);
 

--- a/drivers/power/power_supply_core.c
+++ b/drivers/power/power_supply_core.c
@@ -786,7 +786,9 @@ __power_supply_register(struct device *parent,
 	 */
 	atomic_inc(&psy->use_cnt);
 
-	power_supply_changed(psy);
+	queue_delayed_work(system_power_efficient_wq,
+			   &psy->deferred_register_work,
+			   POWER_SUPPLY_DEFERRED_REGISTER_TIME);
 
 	return psy;
 


### PR DESCRIPTION
Should make the USB psy code work a bit better overall. One of the commits reverts a snippet of code back to what came by default in 4.4, so it should help other drivers that use power_supply as well.