### PR TITLE
Mk2k 4.4: Some anx7418 improvements and fixes.

### DIFF
--- a/drivers/usb/misc/anx7418/anx7418_charger.c
+++ b/drivers/usb/misc/anx7418/anx7418_charger.c
@@ -38,42 +38,34 @@ static int chg_get_property(struct power_supply *psy,
 {
 	struct anx7418_charger *chg = container_of(psy,
 			struct anx7418_charger, psy);
-	struct anx7418 *anx = chg->anx;
-	struct device *cdev = &chg->anx->client->dev;
 	int rc;
+
+	if(!chg) // Don't check the psy if it doesn't exist yet.
+		return -ENODEV;
 
 	switch(prop) {
 	case POWER_SUPPLY_PROP_USB_OTG:
-		dev_dbg(cdev, "%s: is_otg(%d)\n", __func__,
-				chg->is_otg);
 		val->intval = chg->is_otg;
 		break;
 
 	case POWER_SUPPLY_PROP_PRESENT:
-		dev_dbg(cdev, "%s: is_present(%d)\n", __func__,
-				chg->is_present);
 		val->intval = chg->is_present;
 		break;
 
 	case POWER_SUPPLY_PROP_VOLTAGE_MAX:
-		dev_dbg(cdev, "%s: volt_max(%dmV)\n", __func__, chg->volt_max);
 		val->intval = chg->volt_max;
 		break;
 
 	case POWER_SUPPLY_PROP_CURRENT_MAX:
-		dev_dbg(cdev, "%s: curr_max(%dmA)\n", __func__, chg->curr_max);
 		val->intval = chg->curr_max;
 		break;
 
 	case POWER_SUPPLY_PROP_TYPE:
-		dev_dbg(cdev, "%s: type(%s)\n", __func__,
-				chg_to_string(chg->psy.desc->type));
 		val->intval = chg->psy.desc->type;
 		break;
 
 	case POWER_SUPPLY_PROP_TYPEC_MODE:
-		rc = anx7418_read_reg(anx->client, CC_STATUS);
-		dev_dbg(cdev, "%s: CC_STATUS(%02X)\n", __func__, rc);
+		rc = anx7418_read_reg(chg->anx->client, CC_STATUS);
 
 		val->intval = (rc == 0x11) ?
 			POWER_SUPPLY_TYPEC_SINK_DEBUG_ACCESSORY :

--- a/drivers/usb/misc/anx7418/anx7418_pd.c
+++ b/drivers/usb/misc/anx7418/anx7418_pd.c
@@ -498,11 +498,14 @@ static int dswap_req_parse(struct i2c_client *client, const pd_msg_t msg)
 		dev_info(cdev, "Host to Device\n");
 		anx7418_set_dr(anx, DUAL_ROLE_PROP_DR_DEVICE);
 
-		anx->usb_psy->get_property(anx->usb_psy,
+		anx->usb_psy->desc->get_property(anx->usb_psy,
 				POWER_SUPPLY_PROP_TYPE, &prop);
-		if (prop.intval == POWER_SUPPLY_TYPE_UNKNOWN)
-			power_supply_set_supply_type(anx->usb_psy,
-					POWER_SUPPLY_TYPE_USB);
+		if (prop.intval == POWER_SUPPLY_TYPE_UNKNOWN){
+			prop.intval = POWER_SUPPLY_TYPE_USB;
+			power_supply_set_property(anx->usb_psy,
+					POWER_SUPPLY_PROP_TYPE, &prop);
+			anx->usb_psy->desc->type = prop.intval;
+		}
 		break;
 
 	case DUAL_ROLE_PROP_DR_DEVICE:


### PR DESCRIPTION
With the update of chg_get_property in 7418_charger to bring it closer to 7688_core's usbpd_get_property, it seems the G5 no longer faces a kernel panic with the driver enabled and as such, the issue #54 can be considered solved if no other problems arise from those updates.