### PR TITLE
Mk2k 4.4: Continuation of the LG G6 compile error fixes.

### DIFF
--- a/drivers/net/wireless/bcmdhd_ext/wl_cfgvendor.c
+++ b/drivers/net/wireless/bcmdhd_ext/wl_cfgvendor.c
@@ -100,7 +100,7 @@ int wl_cfgvendor_send_async_event(struct wiphy *wiphy,
 #if defined(CONFIG_ARCH_QCOM) && defined(SUPPORT_WDEV_CFG80211_VENDOR_EVENT_ALLOC)
 	skb = cfg80211_vendor_event_alloc(wiphy, NULL, len, event_id, kflags);
 #else
-	skb = cfg80211_vendor_event_alloc(wiphy, len, event_id, kflags);
+	skb = cfg80211_vendor_event_alloc(wiphy, NULL, len, event_id, kflags);
 #endif /* CONFIG_ARCH_QCOM && SUPPORT_WDEV_CFG80211_VENDOR_EVENT_ALLOC */
 	if (!skb) {
 		WL_ERR(("skb alloc failed"));
@@ -299,7 +299,7 @@ wl_cfgvendor_send_hotlist_event(struct wiphy *wiphy,
 #if defined(CONFIG_ARCH_QCOM) && defined(SUPPORT_WDEV_CFG80211_VENDOR_EVENT_ALLOC)
 		skb = cfg80211_vendor_event_alloc(wiphy, NULL, malloc_len, event, kflags);
 #else
-		skb = cfg80211_vendor_event_alloc(wiphy, malloc_len, event, kflags);
+		skb = cfg80211_vendor_event_alloc(wiphy, NULL, malloc_len, event, kflags);
 #endif /* CONFIG_ARCH_QCOM && SUPPORT_WDEV_CFG80211_VENDOR_EVENT_ALLOC */
 		if (!skb) {
 			WL_ERR(("skb alloc failed"));

--- a/drivers/net/wireless/bcmdhd_ext/wl_cfgvendor.c
+++ b/drivers/net/wireless/bcmdhd_ext/wl_cfgvendor.c
@@ -93,14 +93,14 @@ int wl_cfgvendor_send_async_event(struct wiphy *wiphy,
 {
 	u16 kflags;
 	struct sk_buff *skb;
-
+	struct wireless_dev *wdev = ndev_to_wdev(dev);
 	kflags = in_atomic() ? GFP_ATOMIC : GFP_KERNEL;
 
 	/* Alloc the SKB for vendor_event */
 #if defined(CONFIG_ARCH_QCOM) && defined(SUPPORT_WDEV_CFG80211_VENDOR_EVENT_ALLOC)
-	skb = cfg80211_vendor_event_alloc(wiphy, NULL, len, event_id, kflags);
+	skb = cfg80211_vendor_event_alloc(wiphy, wdev, len, event_id, kflags);
 #else
-	skb = cfg80211_vendor_event_alloc(wiphy, NULL, len, event_id, kflags);
+	skb = cfg80211_vendor_event_alloc(wiphy, wdev, len, event_id, kflags);
 #endif /* CONFIG_ARCH_QCOM && SUPPORT_WDEV_CFG80211_VENDOR_EVENT_ALLOC */
 	if (!skb) {
 		WL_ERR(("skb alloc failed"));
@@ -281,6 +281,7 @@ wl_cfgvendor_send_hotlist_event(struct wiphy *wiphy,
 	u16 kflags;
 	const void *ptr;
 	struct sk_buff *skb;
+	struct wireless_dev *wdev = ndev_to_wdev(dev);
 	int malloc_len, total, iter_cnt_to_send, cnt;
 	gscan_results_cache_t *cache = (gscan_results_cache_t *)data;
 	total = len/sizeof(wifi_gscan_result_t);
@@ -297,9 +298,9 @@ wl_cfgvendor_send_hotlist_event(struct wiphy *wiphy,
 
 		/* Alloc the SKB for vendor_event */
 #if defined(CONFIG_ARCH_QCOM) && defined(SUPPORT_WDEV_CFG80211_VENDOR_EVENT_ALLOC)
-		skb = cfg80211_vendor_event_alloc(wiphy, NULL, malloc_len, event, kflags);
+		skb = cfg80211_vendor_event_alloc(wiphy, wdev, malloc_len, event, kflags);
 #else
-		skb = cfg80211_vendor_event_alloc(wiphy, NULL, malloc_len, event, kflags);
+		skb = cfg80211_vendor_event_alloc(wiphy, wdev, malloc_len, event, kflags);
 #endif /* CONFIG_ARCH_QCOM && SUPPORT_WDEV_CFG80211_VENDOR_EVENT_ALLOC */
 		if (!skb) {
 			WL_ERR(("skb alloc failed"));

--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -7590,7 +7590,7 @@ static irqreturn_t otg_fail_handler(int irq, void *_chip)
 	int rc;
 
 	if (chip->bms_psy) {
-		rc = chip->bms_psy->get_property(chip->bms_psy,
+		rc = chip->bms_psy->desc->get_property(chip->bms_psy,
 			POWER_SUPPLY_PROP_VOLTAGE_NOW, &ret);
 		if (rc < 0)
 			pr_smb(PR_LGE, "failed to read Battery Volatge\n");

--- a/drivers/soc/qcom/lge/power/lge_power_class_adc_qct.c
+++ b/drivers/soc/qcom/lge/power/lge_power_class_adc_qct.c
@@ -232,23 +232,23 @@ static int lge_power_adc_get_property(struct lge_power *lpc,
 				mutex_lock(&lge_adc_chip->lock_for_usb_id);
 
 				usb_pd_psy = power_supply_get_by_name("usb_pd");
-				if(usb_pd_psy && usb_pd_psy->get_property) {
-					usb_pd_psy->get_property(usb_pd_psy, POWER_SUPPLY_PROP_TYPEC_MODE, &prop);
+				if(usb_pd_psy && usb_pd_psy->desc->get_property) {
+					usb_pd_psy->desc->get_property(usb_pd_psy, POWER_SUPPLY_PROP_TYPEC_MODE, &prop);
 					typec_accessory = prop.intval;
 					pr_info("usb_pd : %d\n", typec_accessory);
 				}else{
 					pr_info("usb_pd is not ready\n");
 				}
 
-				if(usb_pd_psy && usb_pd_psy->get_property) {
-					usb_pd_psy->get_property(usb_pd_psy, POWER_SUPPLY_PROP_INPUT_SUSPEND, &prop);
+				if(usb_pd_psy && usb_pd_psy->desc->get_property) {
+					usb_pd_psy->desc->get_property(usb_pd_psy, POWER_SUPPLY_PROP_INPUT_SUSPEND, &prop);
 					waterproof = prop.intval;
 					pr_info("waterproof : %d\n", waterproof);
 				}else{
 					pr_info("battery_psy is not ready\n");
 				}
 
-				if ((!waterproof && POWER_SUPPLY_TYPE_CTYPE_DEBUG_ACCESSORY == typec_accessory) ||
+				if ((!waterproof && POWER_SUPPLY_TYPEC_SINK_DEBUG_ACCESSORY == typec_accessory) ||
 				    lge_get_board_rev_no() >= HW_REV_1_3) {
 					/* SBU_EN low, SBU_SEL high */
 					data = 0x11;
@@ -267,7 +267,7 @@ static int lge_power_adc_get_property(struct lge_power *lpc,
 						lge_adc_chip->usb_id_channel, &results);
 
 					/* SBU_EN high */
-					if (typec_accessory != POWER_SUPPLY_TYPE_CTYPE_DEBUG_ACCESSORY) {
+					if (typec_accessory != POWER_SUPPLY_TYPEC_SINK_DEBUG_ACCESSORY) {
 						pr_info("[BSP-USB] SBU EN high: waterproof(%d), physical(%d)\n",
 							waterproof, (int)results.physical);
 						gpiod_direction_output(gpio_to_desc(lge_adc_chip->sbu_en), 1);

--- a/drivers/soc/qcom/lge/power/lge_power_class_charging_controller.c
+++ b/drivers/soc/qcom/lge/power/lge_power_class_charging_controller.c
@@ -769,8 +769,8 @@ static void lge_monitor_batt_temp_work(struct work_struct *work){
 				POWER_SUPPLY_PROP_VOLTAGE_MAX, &ret)) {
 
 				ret.intval = 0;
-				if (cc->bms_psy && cc->bms_psy->set_property &&
-					!cc->bms_psy->set_property(cc->bms_psy,
+				if (cc->bms_psy && cc->bms_psy->desc->set_property &&
+					!cc->bms_psy->desc->set_property(cc->bms_psy,
 						POWER_SUPPLY_PROP_CHARGE_DONE, &ret)) {
 						pr_info("vfloat is restored to %d\n", res.float_voltage);
 				}

--- a/drivers/video/fbdev/msm/lge/lucye/lge_mdss_dsi_panel_lucye.c
+++ b/drivers/video/fbdev/msm/lge/lucye/lge_mdss_dsi_panel_lucye.c
@@ -198,8 +198,8 @@ static int mdss_dsi_request_gpios(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 			goto bklt_en_gpio_err;
 		}
 	}
-	if (gpio_is_valid(ctrl_pdata->mode_gpio)) {
-		rc = gpio_request(ctrl_pdata->mode_gpio, "panel_mode");
+	if (gpio_is_valid(ctrl_pdata->lcd_mode_sel_gpio)) {
+		rc = gpio_request(ctrl_pdata->lcd_mode_sel_gpio, "panel_mode");
 		if (rc) {
 			pr_err("request panel mode gpio failed,rc=%d\n",
 					rc);
@@ -355,15 +355,15 @@ int mdss_dsi_panel_reset(struct mdss_panel_data *pdata, int enable)
 			}
 		}
 #endif
-		if (gpio_is_valid(ctrl_pdata->mode_gpio)) {
+		if (gpio_is_valid(ctrl_pdata->lcd_mode_sel_gpio)) {
 			bool out = false;
 
-			if (pinfo->mode_gpio_state == MODE_GPIO_HIGH)
+			if (pinfo->mode_sel_state == MODE_GPIO_HIGH)
 				out = true;
-			else if (pinfo->mode_gpio_state == MODE_GPIO_LOW)
+			else if (pinfo->mode_sel_state == MODE_GPIO_LOW)
 				out = false;
 
-			rc = gpio_direction_output(ctrl_pdata->mode_gpio, out);
+			rc = gpio_direction_output(ctrl_pdata->lcd_mode_sel_gpio, out);
 			if (rc) {
 				pr_err("%s: unable to set dir for mode gpio\n",
 					__func__);
@@ -387,8 +387,8 @@ int mdss_dsi_panel_reset(struct mdss_panel_data *pdata, int enable)
 		}
 		gpio_set_value((ctrl_pdata->rst_gpio), 0);
 		gpio_free(ctrl_pdata->rst_gpio);
-		if (gpio_is_valid(ctrl_pdata->mode_gpio))
-			gpio_free(ctrl_pdata->mode_gpio);
+		if (gpio_is_valid(ctrl_pdata->lcd_mode_sel_gpio))
+			gpio_free(ctrl_pdata->lcd_mode_sel_gpio);
 	}
 
 exit:


### PR DESCRIPTION
Complementing the recent commits, this PR focuses on the power stack, mdss and wireless drivers.

With this one, all three G6 variants should compile successfully.