### PR TITLE
Mk2k 4.4 new: Patching up G5's anx7418 driver.

### DIFF
--- a/drivers/usb/misc/anx7418/anx7418.c
+++ b/drivers/usb/misc/anx7418/anx7418.c
@@ -420,6 +420,7 @@ static void i2c_work(struct work_struct *w)
 	struct anx7418 *anx = container_of(w, struct anx7418, i2c_work);
 	struct i2c_client *client = anx->client;
 	struct device *cdev = &client->dev;
+	union power_supply_propval otgprop;
 	int irq;
 	int status;
 #ifdef CONFIG_DUAL_ROLE_USB_INTF
@@ -564,7 +565,11 @@ static void i2c_work(struct work_struct *w)
 				anx_dbg_event("DFP", 0);
 
 				anx7418_set_mode(anx, DUAL_ROLE_PROP_MODE_DFP);
-				power_supply_set_usb_otg(&anx->chg.psy, 1);
+				// power_supply_set_usb_otg(&anx->chg.psy, 1);
+				otgprop.intval = 1;
+				power_supply_set_property(&anx->chg.psy, 
+						POWER_SUPPLY_PROP_USB_OTG, &otgprop);
+
 				anx->pr = DUAL_ROLE_PROP_PR_SRC;
 
 				anx7418_set_dr(anx, DUAL_ROLE_PROP_DR_HOST);
@@ -587,11 +592,17 @@ static void i2c_work(struct work_struct *w)
 	if (!(intf_irq_mask & VBUS_CHG) && (irq & VBUS_CHG)) {
 		if (status & VBUS_STATUS) {
 			dev_dbg(cdev, "%s: VBUS ON\n", __func__);
-			power_supply_set_usb_otg(&anx->chg.psy, 1);
+			// power_supply_set_usb_otg(&anx->chg.psy, 1);
+			otgprop.intval = 1;
+			power_supply_set_property(&anx->chg.psy, 
+					POWER_SUPPLY_PROP_USB_OTG, &otgprop);
 			anx->pr = DUAL_ROLE_PROP_PR_SRC;
 		} else {
 			dev_dbg(cdev, "%s: VBUS OFF\n", __func__);
-			power_supply_set_usb_otg(&anx->chg.psy, 0);
+			// power_supply_set_usb_otg(&anx->chg.psy, 0);
+			otgprop.intval = 0;
+			power_supply_set_property(&anx->chg.psy, 
+					POWER_SUPPLY_PROP_USB_OTG, &otgprop);
 			anx->pr = DUAL_ROLE_PROP_PR_SNK;
 		}
 #ifdef CONFIG_DUAL_ROLE_USB_INTF

--- a/drivers/usb/misc/anx7418/anx7418.c
+++ b/drivers/usb/misc/anx7418/anx7418.c
@@ -267,9 +267,9 @@ int anx7418_pwr_on(struct anx7418 *anx, int is_on)
 	struct i2c_client *client = anx->client;
 	struct device *cdev = &client->dev;
 	int rc = 0;
-#ifdef CONFIG_LGE_USB_TYPE_C
+// CONFIG_LGE_USB_TYPE_C START
 	union power_supply_propval prop;
-#endif
+// CONFIG_LGE_USB_TYPE_C END
 
 	dev_info_ratelimited(cdev, "%s(%d)\n", __func__, is_on);
 
@@ -351,9 +351,9 @@ set_as_ufp:
 					 * is connected with a register for distinguish
 					 * factory cables by switch SBU_SEL pin.
 					 */
-#ifdef CONFIG_LGE_USB_TYPE_C
+// CONFIG_LGE_USB_TYPE_C START
 					// Check vbus on?
-					anx->usb_psy->get_property(anx->usb_psy,
+					anx->usb_psy->desc->get_property(anx->usb_psy,
 							POWER_SUPPLY_PROP_DP_DM, &prop);
 					if (prop.intval != POWER_SUPPLY_DP_DM_DPF_DMF) {
 						// vbus not detected
@@ -361,15 +361,7 @@ set_as_ufp:
 						__anx7418_pwr_down(anx);
 						goto out;
 					}
-#endif
-
-#ifdef CONFIG_LGE_USB_TYPE_C
-					prop.intval = 0;
-					rc = anx->batt_psy->set_property(anx->batt_psy,
-							POWER_SUPPLY_PROP_DP_ALT_MODE, &prop);
-					if (rc < 0)
-						dev_err(cdev, "set_property(DP_ALT_MODE) error %d\n", rc);
-#endif
+// CONFIG_LGE_USB_TYPE_C END
 					gpio_set_value(anx->sbu_sel_gpio, 1);
 
 					anx->is_dbg_acc = true;
@@ -1139,7 +1131,7 @@ static int anx7418_probe(struct i2c_client *client,
 		}
 	}
 
-#ifdef CONFIG_LGE_USB_TYPE_C
+// CONFIG_LGE_USB_TYPE_C START
 	anx->usb_psy = power_supply_get_by_name("usb");
 	if (!anx->usb_psy) {
 		dev_err(&client->dev, "usb power_supply_get failed\n");
@@ -1151,7 +1143,7 @@ static int anx7418_probe(struct i2c_client *client,
 		dev_err(&client->dev, "battery power_supply_get failed\n");
 		return -EPROBE_DEFER;
 	}
-#endif
+// CONFIG_LGE_USB_TYPE_C END
 
 	rc = regulator_enable(anx->avdd33);
 	if (rc) {

--- a/drivers/usb/misc/anx7418/anx7418.h
+++ b/drivers/usb/misc/anx7418/anx7418.h
@@ -26,12 +26,11 @@ struct anx7418 {
 
 	/* regulator */
 	struct regulator *avdd33;
-#ifdef CONFIG_LGE_USB_TYPE_C
+//LGE_USB_TYPE_C START
 	struct regulator *vbus_reg;
 	struct power_supply *usb_psy;
 	struct power_supply *batt_psy;
-#endif
-
+//LGE_USB_TYPE_C END
 	/* gpio */
 	int pwr_en_gpio;
 	int resetn_gpio;

--- a/drivers/usb/misc/anx7418/anx7418.h
+++ b/drivers/usb/misc/anx7418/anx7418.h
@@ -4,9 +4,9 @@
 #include <linux/module.h>
 #include <linux/i2c.h>
 #include <linux/workqueue.h>
-#ifdef CONFIG_LGE_USB_TYPE_C
+// CONFIG_LGE_USB_TYPE_C START
 #include <linux/power_supply.h>
-#endif
+// CONFIG_LGE_USB_TYPE_C END
 #include <linux/wakelock.h>
 #include <linux/rwsem.h>
 #include <linux/usb/class-dual-role.h>

--- a/drivers/usb/misc/anx7418/anx7418_charger.c
+++ b/drivers/usb/misc/anx7418/anx7418_charger.c
@@ -315,7 +315,7 @@ int anx7418_charger_init(struct anx7418 *anx)
 {
 	struct anx7418_charger *chg = &anx->chg;
 	struct device *cdev = &anx->client->dev;
-	struct power_supply *usb_psy, *test_psy;
+	struct power_supply *usb_psy;
 	union power_supply_propval usbprop;
 	//int rc;
 	usbprop.intval = 0;
@@ -341,8 +341,8 @@ int anx7418_charger_init(struct anx7418 *anx)
 	INIT_DELAYED_WORK(&chg->chg_work, chg_work);
 
 	//rc = 
-	test_psy = power_supply_register(cdev, chg->psy.desc, NULL);
-	if (!test_psy) {
+	chg->psy = *devm_power_supply_register(cdev, chg->psy.desc, NULL);
+	if (chg->psy.desc->name == NULL) {
 		dev_err(cdev, "Unalbe to register ctype_psy");
 		return -EPROBE_DEFER;
 	}

--- a/drivers/usb/misc/anx7418/anx7418_charger.c
+++ b/drivers/usb/misc/anx7418/anx7418_charger.c
@@ -334,12 +334,10 @@ int anx7418_charger_init(struct anx7418 *anx)
 	chg->psy = *usb_psy;
 
 	chg->anx = anx;
-	dev_info(cdev, "USB_PD_CHARGER configured");
 	INIT_DELAYED_WORK(&chg->chg_work, chg_work);
-	dev_info(cdev, "USB_PD_CHARGER work initialized");
+
 	//rc = 
 	chg->psy = *power_supply_register(cdev, chg->psy.desc, NULL);
-	dev_info(cdev, "USB_PD_CHARGER power_supply registeered");
 	test_psy = &chg->psy;
 	if (!test_psy) {
 		dev_err(cdev, "Unalbe to register ctype_psy");

--- a/drivers/usb/misc/anx7418/anx7418_charger.c
+++ b/drivers/usb/misc/anx7418/anx7418_charger.c
@@ -70,14 +70,14 @@ static int chg_get_property(struct power_supply *psy,
 		val->intval = chg->psy.desc->type;
 		break;
 
-	case POWER_SUPPLY_PROP_TYPEC_MODE:
+	/*case POWER_SUPPLY_PROP_TYPEC_MODE:
 		rc = anx7418_read_reg(anx->client, CC_STATUS);
 		dev_dbg(cdev, "%s: CC_STATUS(%02X)\n", __func__, rc);
 
 		val->intval = (rc == 0x11) ?
 			POWER_SUPPLY_TYPEC_SINK_DEBUG_ACCESSORY :
 			POWER_SUPPLY_TYPE_UNKNOWN;
-		break;
+		break;*/
 
 #if defined(CONFIG_LGE_USB_TYPE_C) && defined(CONFIG_LGE_PM_CHARGING_CONTROLLER)
 	case POWER_SUPPLY_PROP_CTYPE_CHARGER:
@@ -332,18 +332,18 @@ int anx7418_charger_init(struct anx7418 *anx)
 	usb_psy->supplied_to = chg_supplicants;
 	usb_psy->num_supplicants = ARRAY_SIZE(chg_supplicants);
 	chg->psy = *usb_psy;
+	kfree(usb_psy);
 
 	chg->anx = anx;
 	INIT_DELAYED_WORK(&chg->chg_work, chg_work);
 
 	//rc = 
-	chg->psy = *power_supply_register(cdev, chg->psy.desc, NULL);
-	test_psy = &chg->psy;
+	test_psy = power_supply_register(cdev, chg->psy.desc, NULL);
 	if (!test_psy) {
 		dev_err(cdev, "Unalbe to register ctype_psy");
 		return -EPROBE_DEFER;
 	}
-
+	
 	dev_info(cdev, "Charger init done, configured and registered.");
 	return 0;
 }

--- a/drivers/usb/misc/anx7418/anx7418_charger.c
+++ b/drivers/usb/misc/anx7418/anx7418_charger.c
@@ -323,7 +323,7 @@ int anx7418_charger_init(struct anx7418 *anx)
 				GFP_KERNEL);
 
 	usb_psy->desc->name = "usb_pd";
-	usb_psy->desc->type = POWER_SUPPLY_TYPE_TYPEC;
+	usb_psy->desc->type = POWER_SUPPLY_TYPE_UNKNOWN;
 	usb_psy->desc->get_property = chg_get_property;
 	usb_psy->desc->set_property = chg_set_property;
 	usb_psy->desc->property_is_writeable = chg_is_writeable;
@@ -344,9 +344,6 @@ int anx7418_charger_init(struct anx7418 *anx)
 		return -EPROBE_DEFER;
 	}
 
-	//power_supply_set_supply_type(&chg->psy, POWER_SUPPLY_TYPE_UNKNOWN);
-	usbprop.intval = POWER_SUPPLY_TYPE_UNKNOWN;
-	chg->psy.desc->type = usbprop.intval;
 	dev_info(cdev, "Charger init done, configured and registered.");
 	return 0;
 }

--- a/drivers/usb/misc/anx7418/anx7418_charger.c
+++ b/drivers/usb/misc/anx7418/anx7418_charger.c
@@ -2,6 +2,7 @@
 #include <linux/of_gpio.h>
 #include <linux/delay.h>
 #include <linux/regulator/consumer.h>
+#include <linux/slab.h>
 
 #include "anx7418.h"
 #include "anx7418_charger.h"
@@ -70,14 +71,14 @@ static int chg_get_property(struct power_supply *psy,
 		val->intval = chg->psy.desc->type;
 		break;
 
-	/*case POWER_SUPPLY_PROP_TYPEC_MODE:
+	case POWER_SUPPLY_PROP_TYPEC_MODE:
 		rc = anx7418_read_reg(anx->client, CC_STATUS);
 		dev_dbg(cdev, "%s: CC_STATUS(%02X)\n", __func__, rc);
 
 		val->intval = (rc == 0x11) ?
 			POWER_SUPPLY_TYPEC_SINK_DEBUG_ACCESSORY :
 			POWER_SUPPLY_TYPE_UNKNOWN;
-		break;*/
+		break;	
 
 #if defined(CONFIG_LGE_USB_TYPE_C) && defined(CONFIG_LGE_PM_CHARGING_CONTROLLER)
 	case POWER_SUPPLY_PROP_CTYPE_CHARGER:
@@ -295,6 +296,8 @@ static void chg_work(struct work_struct *w)
 		//			POWER_SUPPLY_TYPE_USB_PD);
 		break;
 	default: // unknown charger
+		usbprop.intval = POWER_SUPPLY_TYPE_USB; // enum POWER_SUPPLY_TYPE_USB = 4
+		chg->psy.desc->type = usbprop.intval;
 		goto out;
 	}
 

--- a/drivers/usb/misc/anx7418/anx7418_charger.c
+++ b/drivers/usb/misc/anx7418/anx7418_charger.c
@@ -38,42 +38,34 @@ static int chg_get_property(struct power_supply *psy,
 {
 	struct anx7418_charger *chg = container_of(psy,
 			struct anx7418_charger, psy);
-	struct anx7418 *anx = chg->anx;
-	struct device *cdev = &chg->anx->client->dev;
 	int rc;
+
+	if(!chg) // Don't check the psy if it doesn't exist yet.
+		return -ENODEV;
 
 	switch(prop) {
 	case POWER_SUPPLY_PROP_USB_OTG:
-		dev_dbg(cdev, "%s: is_otg(%d)\n", __func__,
-				chg->is_otg);
 		val->intval = chg->is_otg;
 		break;
 
 	case POWER_SUPPLY_PROP_PRESENT:
-		dev_dbg(cdev, "%s: is_present(%d)\n", __func__,
-				chg->is_present);
 		val->intval = chg->is_present;
 		break;
 
 	case POWER_SUPPLY_PROP_VOLTAGE_MAX:
-		dev_dbg(cdev, "%s: volt_max(%dmV)\n", __func__, chg->volt_max);
 		val->intval = chg->volt_max;
 		break;
 
 	case POWER_SUPPLY_PROP_CURRENT_MAX:
-		dev_dbg(cdev, "%s: curr_max(%dmA)\n", __func__, chg->curr_max);
 		val->intval = chg->curr_max;
 		break;
 
 	case POWER_SUPPLY_PROP_TYPE:
-		dev_dbg(cdev, "%s: type(%s)\n", __func__,
-				chg_to_string(chg->psy.desc->type));
 		val->intval = chg->psy.desc->type;
 		break;
 
 	case POWER_SUPPLY_PROP_TYPEC_MODE:
-		rc = anx7418_read_reg(anx->client, CC_STATUS);
-		dev_dbg(cdev, "%s: CC_STATUS(%02X)\n", __func__, rc);
+		rc = anx7418_read_reg(chg->anx->client, CC_STATUS);
 
 		val->intval = (rc == 0x11) ?
 			POWER_SUPPLY_TYPEC_SINK_DEBUG_ACCESSORY :

--- a/drivers/usb/misc/anx7418/anx7418_charger.h
+++ b/drivers/usb/misc/anx7418/anx7418_charger.h
@@ -15,6 +15,7 @@ enum anx7418_charger_type {
 struct anx7418_charger {
 	struct anx7418 *anx;
 	struct power_supply psy;
+	struct power_supply_desc psy_d;
 
 	bool is_otg;
 	bool is_present;

--- a/drivers/usb/misc/anx7418/anx7418_drp.c
+++ b/drivers/usb/misc/anx7418/anx7418_drp.c
@@ -14,6 +14,7 @@ static bool try_src(struct anx7418 *anx, unsigned long timeout)
 	struct i2c_client *client = anx->client;
 	struct device *cdev = &client->dev;
 	unsigned long expire;
+	union power_supply_propval otgprop;
 
 	wake_lock_timeout(&anx->wlock, msecs_to_jiffies(2000));
 
@@ -22,7 +23,10 @@ static bool try_src(struct anx7418 *anx, unsigned long timeout)
 		return true;
 	}
 
-	power_supply_set_usb_otg(&anx->chg.psy, 0);
+	// power_supply_set_usb_otg(&anx->chg.psy, 0);
+	otgprop.intval = 0;
+	power_supply_set_property(&anx->chg.psy, 
+			POWER_SUPPLY_PROP_USB_OTG, &otgprop);
 	anx->pr = DUAL_ROLE_PROP_PR_SNK;
 
 	anx7418_write_reg(client, RESET_CTRL_0, R_OCM_RESET | R_PD_RESET);
@@ -41,7 +45,11 @@ static bool try_src(struct anx7418 *anx, unsigned long timeout)
 	}
 
 	anx7418_set_mode(anx, DUAL_ROLE_PROP_MODE_DFP);
-	power_supply_set_usb_otg(&anx->chg.psy, 1);
+	// power_supply_set_usb_otg(&anx->chg.psy, 1);
+	otgprop.intval = 1;
+	power_supply_set_property(&anx->chg.psy, 
+			POWER_SUPPLY_PROP_USB_OTG, &otgprop);
+
 	anx->pr = DUAL_ROLE_PROP_PR_SRC;
 	anx7418_set_dr(anx, DUAL_ROLE_PROP_DR_HOST);
 #ifdef CONFIG_DUAL_ROLE_USB_INTF

--- a/drivers/usb/misc/anx7418/anx7418_pd.c
+++ b/drivers/usb/misc/anx7418/anx7418_pd.c
@@ -498,11 +498,14 @@ static int dswap_req_parse(struct i2c_client *client, const pd_msg_t msg)
 		dev_info(cdev, "Host to Device\n");
 		anx7418_set_dr(anx, DUAL_ROLE_PROP_DR_DEVICE);
 
-		anx->usb_psy->get_property(anx->usb_psy,
+		anx->usb_psy->desc->get_property(anx->usb_psy,
 				POWER_SUPPLY_PROP_TYPE, &prop);
-		if (prop.intval == POWER_SUPPLY_TYPE_UNKNOWN)
-			power_supply_set_supply_type(anx->usb_psy,
-					POWER_SUPPLY_TYPE_USB);
+		if (prop.intval == POWER_SUPPLY_TYPE_UNKNOWN){
+			prop.intval = POWER_SUPPLY_TYPE_USB;
+			power_supply_set_property(anx->usb_psy,
+					POWER_SUPPLY_PROP_TYPE, &prop);
+			anx->usb_psy->desc->type = prop.intval;
+		}
 		break;
 
 	case DUAL_ROLE_PROP_DR_DEVICE:

--- a/drivers/usb/misc/anx7418/anx7418_pd.c
+++ b/drivers/usb/misc/anx7418/anx7418_pd.c
@@ -447,7 +447,7 @@ pdo_selected:
 
 static int pswap_req_parse(struct i2c_client *client, const pd_msg_t msg)
 {
-#ifdef CONFIG_LGE_USB_TYPE_C
+// CONFIG_LGE_USB_TYPE_C START
 	struct anx7418 *anx = dev_get_drvdata(&client->dev);
 	struct device *cdev = &anx->client->dev;
 
@@ -476,14 +476,14 @@ static int pswap_req_parse(struct i2c_client *client, const pd_msg_t msg)
 	dual_role_instance_changed(anx->dual_role);
 #endif
 	return 0;
-#else
-	return anx7418_send_pd_msg(client, PD_TYPE_REJECT, 0, 0, PD_SEND_TIMEOUT);
-#endif
+// CONFIG_LGE_USB_TYPE_C ELSE
+	//return anx7418_send_pd_msg(client, PD_TYPE_REJECT, 0, 0, PD_SEND_TIMEOUT);
+// CONFIG_LGE_USB_TYPE_C END
 }
 
 static int dswap_req_parse(struct i2c_client *client, const pd_msg_t msg)
 {
-#ifdef CONFIG_LGE_USB_TYPE_C
+// CONFIG_LGE_USB_TYPE_C START
 	struct device *cdev = &client->dev;
 	struct anx7418 *anx = dev_get_drvdata(cdev);
 	union power_supply_propval prop;
@@ -520,7 +520,7 @@ static int dswap_req_parse(struct i2c_client *client, const pd_msg_t msg)
 #endif
 	return 0;
 err:
-#endif
+// CONFIG_LGE_USB_TYPE_C END
 	return anx7418_send_pd_msg(client, PD_TYPE_REJECT, 0, 0, PD_SEND_TIMEOUT);
 }
 

--- a/drivers/usb/misc/anx7418/anx7418_pd.c
+++ b/drivers/usb/misc/anx7418/anx7418_pd.c
@@ -504,7 +504,7 @@ static int dswap_req_parse(struct i2c_client *client, const pd_msg_t msg)
 			prop.intval = POWER_SUPPLY_TYPE_USB;
 			power_supply_set_property(anx->usb_psy,
 					POWER_SUPPLY_PROP_TYPE, &prop);
-			anx->usb_psy->desc->type = prop.intval;
+			anx->chg.psy_d.type = prop.intval;
 		}
 		break;
 


### PR DESCRIPTION
Just like anx7688, most of the improvements were cherry-picks, with a few extra fixes and updates similar to sony's fusb301 driver on 4.4.