### PR TITLE
Mk2k 4.4 new: New pmi8996 charger thresholds, LG battery profile code from mk2k-4.4, and G6 usb code.

### DIFF
--- a/arch/arm64/boot/dts/lge/g5/common/usb-typec-anx7418.dtsi
+++ b/arch/arm64/boot/dts/lge/g5/common/usb-typec-anx7418.dtsi
@@ -16,6 +16,25 @@
 	qcom,qusb-phy-tune-host = <0x00 0x43 0x00 0x00>;
 };
 
+&pmi8994_charger {
+		qcom,fastchg-current-ma = <3100>;
+		somc,usb-9v-current-max = <1900>;
+		qcom,float-voltage-comp = <0x08>;
+		qcom,float-voltage-mv = <4350>;
+		somc,fastchg-warm-current-ma = <800>;
+		somc,fastchg-cool-current-ma = <800>;
+		somc,thermal-engine-fastchg-current = <3100 2600 2400 1800 1500 1200 800 700 500 300 300 300 300 0 0>;
+		somc,thermal-mitigation-usb-5v = <3100 3100 3100 3100 2600 2600 2600 2600 2600 2400 1200 800 300 0 0>;
+		somc,thermal-mitigation-usb-6v = <2600 2600 2600 2600 2400 2400 2400 2400 2000 1500 900 500 300 0 0>;
+		somc,thermal-mitigation-usb-7v = <2200 2200 2200 2200 1600 1600 1600 1600 1600 1200 900 500 300 0 0>;
+		somc,thermal-mitigation-usb-8v = <1900 1900 1900 1900 1400 1400 1400 1400 1200 900 700 500 300 0 0>;
+		somc,thermal-mitigation-usb-9v = <1900 1900 1900 1900 1400 1400 1400 1400 1000 800 700 500 300 0 0>;
+		somc,limit-usb-5v-level = <8>;
+		qcom,external-typec;
+		qcom,typec-psy-name = "usb_pd";
+		somc,typec-current-max = <3300>;
+};
+
 &i2c_6 {
 	anx7418@28 {
 		compatible = "analogix,anx7418";

--- a/arch/arm64/boot/dts/lge/g6/common/usb-typec-tusb422.dtsi
+++ b/arch/arm64/boot/dts/lge/g6/common/usb-typec-tusb422.dtsi
@@ -20,8 +20,22 @@
 };
 
 &pmi8994_charger {
-        qcom,external-typec;
-        qcom,typec-psy-name = "usb_pd";
+		qcom,fastchg-current-ma = <3100>;
+		somc,usb-9v-current-max = <1900>;
+		qcom,float-voltage-comp = <0x08>;
+		qcom,float-voltage-mv = <4350>;
+		somc,fastchg-warm-current-ma = <800>;
+		somc,fastchg-cool-current-ma = <800>;
+		somc,thermal-engine-fastchg-current = <3100 2600 2400 1800 1500 1200 800 700 500 300 300 300 300 0 0>;
+		somc,thermal-mitigation-usb-5v = <3100 3100 3100 3100 2600 2600 2600 2600 2600 2400 1200 800 300 0 0>;
+		somc,thermal-mitigation-usb-6v = <2600 2600 2600 2600 2400 2400 2400 2400 2000 1500 900 500 300 0 0>;
+		somc,thermal-mitigation-usb-7v = <2200 2200 2200 2200 1600 1600 1600 1600 1600 1200 900 500 300 0 0>;
+		somc,thermal-mitigation-usb-8v = <1900 1900 1900 1900 1400 1400 1400 1400 1200 900 700 500 300 0 0>;
+		somc,thermal-mitigation-usb-9v = <1900 1900 1900 1900 1400 1400 1400 1400 1000 800 700 500 300 0 0>;
+		somc,limit-usb-5v-level = <8>;
+		qcom,external-typec;
+		qcom,typec-psy-name = "usb_pd";
+		somc,typec-current-max = <3300>;
 };
 
 &i2c_6 {

--- a/arch/arm64/boot/dts/lge/v20/common/usb-typec-anx7688.dtsi
+++ b/arch/arm64/boot/dts/lge/v20/common/usb-typec-anx7688.dtsi
@@ -25,6 +25,25 @@
 	qcom,qusb-phy-tune-host = <0xF8 0x73 0x83 0xC5>;
 };
 
+&pmi8994_charger {
+		qcom,fastchg-current-ma = <3100>;
+		somc,usb-9v-current-max = <1900>;
+		qcom,float-voltage-comp = <0x08>;
+		qcom,float-voltage-mv = <4350>;
+		somc,fastchg-warm-current-ma = <800>;
+		somc,fastchg-cool-current-ma = <800>;
+		somc,thermal-engine-fastchg-current = <3100 2600 2400 1800 1500 1200 800 700 500 300 300 300 300 0 0>;
+		somc,thermal-mitigation-usb-5v = <3100 3100 3100 3100 2600 2600 2600 2600 2600 2400 1200 800 300 0 0>;
+		somc,thermal-mitigation-usb-6v = <2600 2600 2600 2600 2400 2400 2400 2400 2000 1500 900 500 300 0 0>;
+		somc,thermal-mitigation-usb-7v = <2200 2200 2200 2200 1600 1600 1600 1600 1600 1200 900 500 300 0 0>;
+		somc,thermal-mitigation-usb-8v = <1900 1900 1900 1900 1400 1400 1400 1400 1200 900 700 500 300 0 0>;
+		somc,thermal-mitigation-usb-9v = <1900 1900 1900 1900 1400 1400 1400 1400 1000 800 700 500 300 0 0>;
+		somc,limit-usb-5v-level = <8>;
+		qcom,external-typec;
+		qcom,typec-psy-name = "usb_pd";
+		somc,typec-current-max = <3300>;
+};
+
 &i2c_6 {
 	anx7688-usbc@28 {
 		compatible = "analogix,anx7688-usbc";

--- a/drivers/power/supply/qcom/Makefile
+++ b/drivers/power/supply/qcom/Makefile
@@ -11,3 +11,6 @@ obj-$(CONFIG_BATTERY_BCL) += battery_current_limit.o
 obj-$(CONFIG_QPNP_SMB2)		+= step-chg-jeita.o battery.o qpnp-smb2.o smb-lib.o pmic-voter.o storm-watch.o
 obj-$(CONFIG_SMB138X_CHARGER)	+= battery.o smb138x-charger.o smb-lib.o pmic-voter.o storm-watch.o
 obj-$(CONFIG_QPNP_QNOVO)	+= battery.o qpnp-qnovo.o
+
+#Could be made a bit more modular, so as not to compile it all the time with only LGE_PM, we won't need the whole subdir as well
+obj-$(CONFIG_LGE_PM) += /lge/lge_batt_detection.o

--- a/drivers/power/supply/qcom/lge/lge_batt_detection.c
+++ b/drivers/power/supply/qcom/lge/lge_batt_detection.c
@@ -1,0 +1,26 @@
+#define pr_fmt(fmt) "LGE_BATT_DETECT: %s: " fmt, __func__
+
+#include "lge_batt_detection.h"
+
+char *return_lge_battery_name(){
+	char *lge_batt_profile_name = NULL;
+	
+#if defined (CONFIG_MACH_MSM8996_ELSA) || defined (CONFIG_MACH_MSM8996_ANNA) // V20, ANNA
+#if defined(CONFIG_MACH_MSM8996_ELSA_DCM_JP) || defined(CONFIG_MACH_MSM8996_ELSA_KDDI_JP) // Jap V20
+	lge_batt_profile_name = "LGE_BLT28_Tocad_3000mAh"; // The 3000mAh batt from Japanese V20
+#else // If it isn't a japanese V20, get the standard 3200mAh battery profile
+	lge_batt_profile_name = "LGE_BL44E1F_LGC_3200mAh"; // For V20 and whatever ANNA is.
+#endif 
+#endif // End of the V20 batt check
+
+#if defined (CONFIG_MACH_MSM8996_H1) // G5
+	lge_batt_profile_name = "generic_2810mah_sept9th2015"; // Default G5 Battery in lge_battery_id.h
+#endif
+
+#if defined (CONFIG_MACH_MSM8996_LUCYE) // G6
+	lge_batt_profile_name = "LGE_BLT32_LGC_3300mAh"; //Standard G6 battery
+#endif
+
+	pr_debug("Battery name: %s", lge_batt_profile_name);
+	return lge_batt_profile_name;
+}

--- a/drivers/power/supply/qcom/lge/lge_batt_detection.h
+++ b/drivers/power/supply/qcom/lge/lge_batt_detection.h
@@ -1,0 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/types.h>
+#include <linux/kernel.h>
+
+/*Overrides the default battery type string with the values 
+  from lge_battery_id.h to get the correct battery profile
+  for the phones and enable battery metrics, iterated version
+  now has an improved and more flexible naming scheme to enable
+  further improvements*/
+char *return_lge_battery_name(void);

--- a/drivers/power/supply/qcom/qpnp-fg.c
+++ b/drivers/power/supply/qcom/qpnp-fg.c
@@ -41,6 +41,9 @@
 #ifdef CONFIG_QPNP_FG_EXTENSION
 #include "qpnp-fg_extension_param.h"
 #endif
+#if defined (CONFIG_MACH_MSM8996_ELSA) || defined (CONFIG_MACH_MSM8996_ANNA) || defined (CONFIG_MACH_MSM8996_H1) || defined (CONFIG_MACH_MSM8996_LUCYE)
+#include "lge/lge_batt_detection.h"
+#endif
 
 /* Register offsets */
 
@@ -6689,6 +6692,10 @@ static int fg_batt_profile_init(struct fg_chip *chip)
 	const char *data, *batt_type_str;
 	bool tried_again = false, vbat_in_range, profiles_same;
 	u8 reg = 0;
+
+#if defined (CONFIG_MACH_MSM8996_ELSA) || defined (CONFIG_MACH_MSM8996_ANNA) || defined (CONFIG_MACH_MSM8996_H1) || defined (CONFIG_MACH_MSM8996_LUCYE)
+	fg_batt_type = return_lge_battery_name();
+#endif
 
 wait:
 	fg_stay_awake(&chip->profile_wakeup_source);

--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -50,6 +50,9 @@
 #include "qpnp-smbcharger_extension_param.h"
 #include "qpnp-smbcharger_extension_usb.h"
 #endif
+#if defined (CONFIG_MACH_MSM8996_ELSA) || defined (CONFIG_MACH_MSM8996_ANNA) || defined (CONFIG_MACH_MSM8996_H1) || defined (CONFIG_MACH_MSM8996_LUCYE)
+#include "lge/lge_batt_detection.h"
+#endif
 
 /* Mask/Bit helpers */
 #define _SMB_MASK(BITS, POS) \
@@ -3801,6 +3804,9 @@ static int smbchg_config_chg_battery_type(struct smbchg_chip *chip)
 	struct device_node *batt_node, *profile_node;
 	struct device_node *node = chip->pdev->dev.of_node;
 	union power_supply_propval prop = {0,};
+#if defined (CONFIG_MACH_MSM8996_ELSA) || defined (CONFIG_MACH_MSM8996_ANNA) || defined (CONFIG_MACH_MSM8996_H1) || defined (CONFIG_MACH_MSM8996_LUCYE)
+	const char *batt_string = return_lge_battery_name();
+#endif
 
 	rc = power_supply_get_property(chip->bms_psy,
 			POWER_SUPPLY_PROP_BATTERY_TYPE, &prop);
@@ -3831,8 +3837,13 @@ static int smbchg_config_chg_battery_type(struct smbchg_chip *chip)
 		return 0;
 	}
 
+#if defined (CONFIG_MACH_MSM8996_ELSA) || defined (CONFIG_MACH_MSM8996_ANNA) || defined (CONFIG_MACH_MSM8996_H1) || defined (CONFIG_MACH_MSM8996_LUCYE)
+	profile_node = of_batterydata_get_best_profile(batt_node,
+				prop.intval / 1000, batt_string);
+#else
 	profile_node = of_batterydata_get_best_profile(batt_node,
 				prop.intval / 1000, NULL);
+#endif
 	if (IS_ERR_OR_NULL(profile_node)) {
 		rc = PTR_ERR(profile_node);
 		pr_err("couldn't find profile handle %d\n", rc);

--- a/drivers/usb/misc/Kconfig
+++ b/drivers/usb/misc/Kconfig
@@ -293,6 +293,14 @@ config USB_QCOM_DIAG_BRIDGE
 	  To compile this driver as a module, choose M here: the
 	  module will be called diag_bridge.  If unsure, choose N.
 
+config LGE_USB_TYPE_C
+	bool "Enable dummy LGE_USB_TYPE_C used by some USB drivers"
+	help
+	  Say Y here if you are compiling to an LGE msm8996/pro device and
+	  its usb drivers depend on LGE_USB_TYPE_C in some capacity
+	  (ANX7688, ANX7418 and TUSB422 do) for extra code activation or
+	  functionality.
+
 source "drivers/usb/misc/anx7418/Kconfig"
 source "drivers/usb/misc/anx7688/Kconfig"
 source "drivers/usb/misc/tusb422/Kconfig"

--- a/drivers/usb/misc/tusb422/lge/hw_pd_dev.c
+++ b/drivers/usb/misc/tusb422/lge/hw_pd_dev.c
@@ -75,6 +75,7 @@ int set_mode(struct hw_pd_dev *dev, int mode)
 
 int set_pr(struct hw_pd_dev *dev, int pr)
 {
+	union power_supply_propval prop;
 	static const char *const strings[] = {
 		[DUAL_ROLE_PROP_PR_SRC]		= "Source",
 		[DUAL_ROLE_PROP_PR_SNK]		= "Sink",
@@ -86,12 +87,18 @@ int set_pr(struct hw_pd_dev *dev, int pr)
 
 	switch (pr) {
 	case DUAL_ROLE_PROP_PR_SRC:
-		power_supply_set_usb_otg(&dev->chg_psy, 1);
+		prop.intval = 1;
+		power_supply_set_property(&dev->chg_psy, 
+			POWER_SUPPLY_PROP_USB_OTG, &prop);
+		//power_supply_set_usb_otg(&dev->chg_psy, 1);
 		break;
 
 	case DUAL_ROLE_PROP_PR_SNK:
 	case DUAL_ROLE_PROP_PR_NONE:
-		power_supply_set_usb_otg(&dev->chg_psy, 0);
+		prop.intval = 0;
+		power_supply_set_property(&dev->chg_psy, 
+			POWER_SUPPLY_PROP_USB_OTG, &prop);
+		//power_supply_set_usb_otg(&dev->chg_psy, 0);
 		break;
 
 	default:
@@ -108,6 +115,7 @@ int set_pr(struct hw_pd_dev *dev, int pr)
 
 int set_dr(struct hw_pd_dev *dev, int dr)
 {
+	union power_supply_propval prop;
 	static const char *const strings[] = {
 		[DUAL_ROLE_PROP_DR_HOST]	= "Host",
 		[DUAL_ROLE_PROP_DR_DEVICE]	= "Device",
@@ -120,19 +128,30 @@ int set_dr(struct hw_pd_dev *dev, int dr)
 	switch (dr) {
 	case DUAL_ROLE_PROP_DR_HOST:
 		set_dr(dev, DUAL_ROLE_PROP_DR_NONE);
-		power_supply_set_usb_otg(dev->usb_psy, 1);
+		prop.intval = 1;
+		power_supply_set_property(&dev->chg_psy, 
+			POWER_SUPPLY_PROP_USB_OTG, &prop);
+		//power_supply_set_usb_otg(dev->usb_psy, 1);
 		break;
 
 	case DUAL_ROLE_PROP_DR_DEVICE:
 		set_dr(dev, DUAL_ROLE_PROP_DR_NONE);
-		power_supply_set_present(dev->usb_psy, 1);
+		prop.intval = 1;
+		power_supply_set_property(&dev->chg_psy, 
+			POWER_SUPPLY_PROP_USB_OTG, &prop);
+		//power_supply_set_present(dev->usb_psy, 1);
 		break;
 
 	case DUAL_ROLE_PROP_DR_NONE:
+		prop.intval = 0;
 		if (dev->dr == DUAL_ROLE_PROP_DR_HOST)
-			power_supply_set_usb_otg(dev->usb_psy, 0);
+			power_supply_set_property(&dev->chg_psy, 
+						POWER_SUPPLY_PROP_USB_OTG, &prop);
+			//power_supply_set_usb_otg(dev->usb_psy, 0);
 		if (dev->dr == DUAL_ROLE_PROP_DR_DEVICE)
-			power_supply_set_present(dev->usb_psy, 0);
+			power_supply_set_property(&dev->chg_psy, 
+						POWER_SUPPLY_PROP_USB_OTG, &prop);
+			//power_supply_set_present(dev->usb_psy, 0);
 		break;
 
 	default:
@@ -175,7 +194,7 @@ int pd_dpm_handle_pe_event(enum pd_dpm_pe_evt event, void *state)
 	switch (event) {
 	case PD_DPM_PE_EVT_SOURCE_VBUS:
 		set_pr(dev, DUAL_ROLE_PROP_PR_SRC);
-		dev->chg_psy.type = POWER_SUPPLY_TYPE_DFP;
+		dev->chg_psy_d.type = POWER_SUPPLY_TYPE_DFP;
 		break;
 
 	case PD_DPM_PE_EVT_DIS_VBUS_CTRL:
@@ -185,16 +204,16 @@ int pd_dpm_handle_pe_event(enum pd_dpm_pe_evt event, void *state)
 			set_pr(dev, DUAL_ROLE_PROP_PR_NONE);
 		}
 
-		dev->chg_psy.type = POWER_SUPPLY_TYPE_UNKNOWN;
+		dev->chg_psy_d.type = POWER_SUPPLY_TYPE_UNKNOWN;
 		dev->curr_max = 0;
 		dev->volt_max = 0;
 
 		if (dev->rp) {
 			dev->rp = 0;
 			prop.intval = 0;
-			set_property_to_battery(dev,
-						POWER_SUPPLY_PROP_CTYPE_RP,
-						&prop);
+			//set_property_to_battery(dev,
+			//			POWER_SUPPLY_PROP_CTYPE_RP, TODO: Either add that prop, or work around it.
+			//			&prop);
 		}
 		break;
 
@@ -209,12 +228,12 @@ int pd_dpm_handle_pe_event(enum pd_dpm_pe_evt event, void *state)
 		set_pr(dev, DUAL_ROLE_PROP_PR_SNK);
 
 		if (vbus_state->vbus_type) {
-			if (dev->chg_psy.type == POWER_SUPPLY_TYPE_CTYPE_PD &&
+			if (dev->chg_psy_d.type == POWER_SUPPLY_TYPE_USB_PD &&
 			    dev->volt_max == vbus_state->mv &&
 			    dev->curr_max == vbus_state->ma)
 				goto print_vbus_state;
 
-			dev->chg_psy.type = POWER_SUPPLY_TYPE_CTYPE_PD;
+			dev->chg_psy_d.type = POWER_SUPPLY_TYPE_USB_PD;
 			dev->volt_max = vbus_state->mv;
 			dev->curr_max = vbus_state->ma;
 
@@ -226,8 +245,8 @@ int pd_dpm_handle_pe_event(enum pd_dpm_pe_evt event, void *state)
 			uint16_t ma = vbus_state->ma;
 			int rp = 0;
 
-			if (dev->chg_psy.type == POWER_SUPPLY_TYPE_USB_HVDCP ||
-			    dev->chg_psy.type == POWER_SUPPLY_TYPE_USB_HVDCP_3) {
+			if (dev->chg_psy_d.type == POWER_SUPPLY_TYPE_USB_HVDCP ||
+			    dev->chg_psy_d.type == POWER_SUPPLY_TYPE_USB_HVDCP_3) {
 				DEBUG("HVDCP is present. ignore Rp advertisement\n");
 				if (dev->curr_max) {
 					dev->curr_max = 0;
@@ -264,9 +283,9 @@ int pd_dpm_handle_pe_event(enum pd_dpm_pe_evt event, void *state)
 			if (rp && !dev->rp) {
 				dev->rp = rp;
 				prop.intval = dev->rp;
-				set_property_to_battery(dev,
-							POWER_SUPPLY_PROP_CTYPE_RP,
-							&prop);
+				//set_property_to_battery(dev,
+				//			POWER_SUPPLY_PROP_CTYPE_RP, TODO: Either add that prop, or work around it.
+				//			&prop);
 			}
 
 			if (dev->volt_max == vbus_state->mv &&
@@ -285,8 +304,8 @@ int pd_dpm_handle_pe_event(enum pd_dpm_pe_evt event, void *state)
 print_vbus_state:
 		PRINT("%s: %s, %dmV, %dmA\n", __func__,
 		      chg_to_string(vbus_state->vbus_type ?
-				    POWER_SUPPLY_TYPE_CTYPE_PD :
-				    POWER_SUPPLY_TYPE_CTYPE),
+				    POWER_SUPPLY_TYPE_USB_PD :
+				    POWER_SUPPLY_TYPE_TYPEC),
 		      vbus_state->mv,
 		      vbus_state->ma);
 		break;
@@ -321,14 +340,16 @@ print_vbus_state:
 		case PD_DPM_TYPEC_UNATTACHED:
 			dev->typec_mode = POWER_SUPPLY_TYPE_UNKNOWN;
 
-			if (dev->mode == DUAL_ROLE_PROP_MODE_FAULT) {
 #ifdef CONFIG_LGE_PM_WATERPROOF_PROTECTION
+			if (dev->mode == DUAL_ROLE_PROP_MODE_FAULT) {
+
 				prop.intval = 0;
 				set_property_to_battery(dev,
 							POWER_SUPPLY_PROP_INPUT_SUSPEND,
 							&prop);
-#endif
+
 			}
+#endif
 
 #ifdef CONFIG_LGE_USB_MOISTURE_DETECT
 			if (dev->is_sbu_ov) {
@@ -378,7 +399,7 @@ print_vbus_state:
 			set_pr(dev, DUAL_ROLE_PROP_PR_NONE);
 			set_dr(dev, DUAL_ROLE_PROP_DR_NONE);
 
-			dev->chg_psy.type = POWER_SUPPLY_TYPE_UNKNOWN;
+			dev->chg_psy_d.type = POWER_SUPPLY_TYPE_UNKNOWN;
 			dev->curr_max = 0;
 			dev->volt_max = 0;
 
@@ -408,7 +429,9 @@ print_vbus_state:
 			(struct pd_dpm_swap_state *)state;
 		switch (swap_state->new_role) {
 		case PD_DATA_ROLE_UFP:
-			power_supply_set_supply_type(dev->usb_psy, POWER_SUPPLY_TYPE_USB);
+			prop.intval = POWER_SUPPLY_TYPE_USB;
+			power_supply_set_property(dev->usb_psy, POWER_SUPPLY_PROP_TYPE, &prop);
+			//power_supply_set_supply_type(dev->usb_psy, POWER_SUPPLY_TYPE_USB);
 			set_dr(dev, DUAL_ROLE_PROP_DR_DEVICE);
 			break;
 

--- a/drivers/usb/misc/tusb422/lge/hw_pd_dev.h
+++ b/drivers/usb/misc/tusb422/lge/hw_pd_dev.h
@@ -16,7 +16,6 @@
 #include <linux/usb/class-dual-role.h>
 
 #include <soc/qcom/lge/board_lge.h>
-#include <soc/qcom/lge/power/lge_board_revision.h>
 
 #if defined(CONFIG_LGE_USB_DEBUGGER) || defined(CONFIG_LGE_USB_MOISTURE_DETECT)
 #include <soc/qcom/lge/power/lge_power_class.h>
@@ -60,7 +59,9 @@ struct hw_pd_dev {
 	struct delayed_work otg_work;
 
 	struct power_supply chg_psy;
+	struct power_supply_desc chg_psy_d;
 	struct power_supply *batt_psy;
+	struct power_supply_desc batt_psy_d;
 
 	bool is_otg;
 	bool is_present;

--- a/include/linux/usb/class-dual-role.h
+++ b/include/linux/usb/class-dual-role.h
@@ -47,13 +47,83 @@ enum {
 	DUAL_ROLE_PROP_VCONN_SUPPLY_TOTAL,
 };
 
+#ifdef CONFIG_LGE_USB_TYPE_C
+enum {
+	DUAL_ROLE_PROP_CC_OPEN = 0,
+	DUAL_ROLE_PROP_CC_RP_DEFAULT,
+	DUAL_ROLE_PROP_CC_RP_POWER1P5,
+	DUAL_ROLE_PROP_CC_RP_POWER3P0,
+	DUAL_ROLE_PROP_CC_RD,
+	DUAL_ROLE_PROP_CC_RA,
+/*The following should be the last element*/
+	DUAL_ROLE_PROP_CC_TOTAL,
+};
+#endif
+
 enum dual_role_property {
 	DUAL_ROLE_PROP_SUPPORTED_MODES = 0,
 	DUAL_ROLE_PROP_MODE,
 	DUAL_ROLE_PROP_PR,
 	DUAL_ROLE_PROP_DR,
 	DUAL_ROLE_PROP_VCONN_SUPPLY,
+#ifdef CONFIG_LGE_USB_TYPE_C
+	DUAL_ROLE_PROP_CC1,
+	DUAL_ROLE_PROP_CC2,
+	DUAL_ROLE_PROP_PDO1,
+	DUAL_ROLE_PROP_PDO2,
+	DUAL_ROLE_PROP_PDO3,
+	DUAL_ROLE_PROP_PDO4,
+	DUAL_ROLE_PROP_RDO,
+#endif
 };
+
+#ifdef CONFIG_LGE_USB_TYPE_C
+/* PDO */
+enum {
+	DUAL_ROLE_PROP_PDO_TYPE_FIXED,
+	DUAL_ROLE_PROP_PDO_TYPE_BATTERY,
+	DUAL_ROLE_PROP_PDO_TYPE_VARIABLE,
+};
+
+#define DUAL_ROLE_PROP_PDO_SET_TYPE(type)	(((type) & 0x3) << 30)
+
+#define DUAL_ROLE_PROP_PDO_SET_FIXED_VOLT(mV)	((((mV) / 50U) & 0x3FF) << 10)
+#define DUAL_ROLE_PROP_PDO_SET_FIXED_CURR(mA)	(((mA) / 10U) & 0x3FF)
+
+#define DUAL_ROLE_PROP_PDO_SET_BATTERY_MAX_VOLT(mV)  ((((mV) / 50U) & 0x3FF) << 20)
+#define DUAL_ROLE_PROP_PDO_SET_BATTERY_MIN_VOLT(mV)  ((((mV) / 50U) & 0x3FF) << 10)
+#define DUAL_ROLE_PROP_PDO_SET_BATTERY_MAX_POWER(mW) (((mV) / 250U) & 0x3FF)
+
+#define DUAL_ROLE_PROP_PDO_SET_VARIABLE_MAX_VOLT(mV) ((((mV) / 50U) & 0x3FF) << 20)
+#define DUAL_ROLE_PROP_PDO_SET_VARIABLE_MIN_VOLT(mV) ((((mV) / 50U) & 0x3FF) << 10)
+#define DUAL_ROLE_PROP_PDO_SET_VARIABLE_MAX_CURR(mW) (((mW) / 10U) & 0x3FF)
+
+#define DUAL_ROLE_PROP_PDO_GET_TYPE(pdo)	(((pdo) >> 30) & 0x3)
+
+#define DUAL_ROLE_PROP_PDO_GET_FIXED_VOLT(pdo)	((((pdo) >> 10) & 0x3FF) * 50U)
+#define DUAL_ROLE_PROP_PDO_GET_FIXED_CURR(pdo)	(((pdo) & 0x3FF) * 10U)
+
+#define DUAL_ROLE_PROP_PDO_GET_BATTERY_MAX_VOLT(pdo)  ((((pdo) >> 20) & 0x3FF) * 50U)
+#define DUAL_ROLE_PROP_PDO_GET_BATTERY_MIN_VOLT(pdo)  ((((pdo) >> 10) & 0x3FF) * 50U)
+#define DUAL_ROLE_PROP_PDO_GET_BATTERY_MAX_POWER(pdo) (((pdo) & 0x3FF) * 250U)
+
+#define DUAL_ROLE_PROP_PDO_GET_VARIABLE_MAX_VOLT(pdo) ((((pdo) >> 20) & 0x3FF) * 50U)
+#define DUAL_ROLE_PROP_PDO_GET_VARIABLE_MIN_VOLT(pdo) ((((pdo) >> 10) & 0x3FF) * 50U)
+#define DUAL_ROLE_PROP_PDO_GET_VARIABLE_MAX_CURR(pdo) (((pdo) & 0x3FF) * 10U)
+
+/* RDO */
+#define DUAL_ROLE_PROP_RDO_SET_OBJ_POS(pos)	(((pos) & 0x7) << 28)
+#define DUAL_ROLE_PROP_RDO_SET_OP_CURR(mA)	((((mA) / 10U) & 0x3FF) << 10)
+#define DUAL_ROLE_PROP_RDO_SET_MIN_CURR(mA)	((((mA) / 10U) & 0x3FF)
+#define DUAL_ROLE_PROP_RDO_SET_OP_POWER(mW)	((((mW) / 250U) & 0x3FF) << 10)
+#define DUAL_ROLE_PROP_RDO_SET_MIN_POWER(mW)	((((mW) / 250U) & 0x3FF)
+
+#define DUAL_ROLE_PROP_RDO_GET_OBJ_POS(rdo)	(((rdo) >> 28) & 0x7)
+#define DUAL_ROLE_PROP_RDO_GET_OP_CURR(rdo)	((((rdo) >> 10) & 0x3FF) * 10U)
+#define DUAL_ROLE_PROP_RDO_GET_MIN_CURR(rdo)	(((rdo) & 0x3FF) * 10U)
+#define DUAL_ROLE_PROP_RDO_GET_OP_POWER(rdo)	((((rdo) >> 10) & 0x3FF) * 250U)
+#define DUAL_ROLE_PROP_RDO_GET_MIN_POWER(rdo)	(((rdo) & 0x3FF) * 250U)
+#endif
 
 struct dual_role_phy_instance;
 


### PR DESCRIPTION
This PR has the following updates:
General improvements for the usb stack in order to get the G6's updated tusb driver up an running. 
A port of the battery profile code from the prev 4.4 branch with some adjustments for the cleaner source.
The addition of some charge thresholds for the G5, V20 and G6 based on their spec sheets, which are mostly identical.